### PR TITLE
Add post-release docs (utility scripts, Docker composition) and bin/deploy.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,40 @@ LEFT JOIN whitelist_mails wm ON bm.recipient = wm.recipient AND bm.senderdomain 
 WHERE bm.senderdomain = 'example.com' AND wm.id IS NULL
 ```
 
+## Utility Scripts
+
+These scripts live at the repository root (not under `bin/`) and are invoked manually rather than through Rails tasks. README.md documents the operational usage; the notes here cover what each one does and how it relates to the rest of the codebase.
+
+### `update-sisto-db.rb`
+Sisimai-based bounce ingestion script. Reads bounce emails from a Maildir-style directory (passed as the first argv), parses them with `Sisimai.rise`, and inserts each result into `bounce_mails`. Connects directly to MySQL (`bounce` / `bounce` / `sisito_development`) without going through ActiveRecord, so timestamps are stored via `FROM_UNIXTIME(...)` and the `digest` column is populated with `SHA1(recipient)`. The Postfix container's `/collect.rb` is a similar in-container variant.
+
+```bash
+ruby update-sisto-db.rb /var/spool/sisito/mail
+```
+
+### `monitor_performance.rb`
+Standalone MySQL performance monitor. Reports running queries (>5s), table size and index ratio for `bounce_mails`, presence of the three performance indexes (`idx_timestamp_addresser`, `idx_reason_destination`, `idx_recipient_senderdomain_timestamp`), and key InnoDB memory variables (`innodb_buffer_pool_size`, `tmp_table_size`, `sort_buffer_size`). Runs against `sisito_development` by default — edit the connection block when targeting other environments.
+
+```bash
+ruby monitor_performance.rb
+```
+
+### `mysql_optimization.cnf`
+Production MySQL/MariaDB tuning preset. Copy to `/etc/mysql/mysql.conf.d/sisito_optimization.cnf` (MySQL) or `/etc/mysql/mariadb.conf.d/sisito_optimization.cnf` (MariaDB) and restart the server. Tuned for bounce aggregation workloads: 2 GB `innodb_buffer_pool_size`, 1 GB `tmp_table_size`, 512 MB query cache, slow query log enabled at 5 s. Adjust `innodb_buffer_pool_size` to ~70–80% of available RAM before applying.
+
+## Docker Composition
+
+`docker-compose.yml` orchestrates four services. Three of them have their own Dockerfile at the repository root; MySQL uses an upstream image directly.
+
+| Service      | Dockerfile              | Base image              | Role |
+|--------------|-------------------------|-------------------------|------|
+| `sisito`     | `Dockerfile.sisito`     | `ubuntu:jammy-20221003` | Rails app (Puma). Runs `bundle install --deployment`, then `migrate.sh` → `init.sh` via `entrykit` + `dumb-init`. Timezone forced to Asia/Tokyo. SMTP port rewritten 25 → 1025 to point at Mailcatcher. |
+| `sisito_api` | `Dockerfile.sisito-api` | `alpine`                | Go binary `sisito-api`, downloaded pre-built from `winebarrel/sisito-api` GitHub Releases (version pinned via the `SISITO_API_VERSION` ARG). Serves `/blacklist` and related JSON endpoints on :8080. |
+| `postfix`    | `Dockerfile.postfix`    | `ubuntu:jammy-20221003` | Bounce-receiving Postfix + `sisimai` + `mysql2`. The container-internal `/collect.rb` parses incoming bounces and inserts them into the shared MySQL. |
+| `mysql`      | (image: `mysql:8.0.32`) | —                       | Shared database. `MYSQL_ALLOW_EMPTY_PASSWORD=1`, TZ=Asia/Tokyo. |
+
+Mailcatcher's web UI is exposed on host port `11080` from the `sisito` container (port `1080` inside).
+
 ## Development Patterns
 
 ### Code Style

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Manual deploy helper for Raspberry Pi (or any host running sisito directly,
+# without docker-compose). Idempotent: safe to run repeatedly.
+#
+# Aborts on local uncommitted changes or non-fast-forward divergence to keep
+# production state predictable. Run from anywhere; it cd's to the project root.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+git fetch origin
+git pull --ff-only origin master
+
+mise install
+mise exec -- bundle install --deployment --without development test
+
+RAILS_ENV=production mise exec -- bundle exec rails db:migrate
+RAILS_ENV=production SECRET_KEY_BASE_DUMMY=1 mise exec -- bundle exec rails assets:precompile
+
+# Restart Puma via tmp/restart.txt (config/puma.rb has `plugin :tmp_restart`).
+# If the server is not currently running, leave startup to the operator
+# to preserve their existing screen/tmux/nohup wrapping.
+if [ -f tmp/pids/server.pid ] && kill -0 "$(cat tmp/pids/server.pid)" 2>/dev/null; then
+  mise exec -- bundle exec rails restart
+  echo "Deploy done. Puma reloaded via tmp/restart.txt."
+else
+  echo "Deploy done. Rails server is not running; start it manually:"
+  echo "  RAILS_ENV=production mise exec -- bundle exec rails server -p 1080 -b 0.0.0.0"
+fi


### PR DESCRIPTION
Closes #11

## Summary

- Add `## Utility Scripts` and `## Docker Composition` sections to CLAUDE.md, covering the repository-root scripts (`update-sisto-db.rb`, `monitor_performance.rb`, `mysql_optimization.cnf`) and the per-service Dockerfiles (`Dockerfile.sisito`, `Dockerfile.sisito-api`, `Dockerfile.postfix`).
- Add `bin/deploy.sh`: an idempotent manual-deploy helper for hosts that run sisito directly (currently the Raspberry Pi production environment).

## Context

Both items were proposed earlier and deferred while PR #9 (Rails 7.2.3.1 security patch) was in flight.

README.md already documents operator-facing usage of the utility scripts and `mysql_optimization.cnf`; the CLAUDE.md additions intentionally focus on architectural context (purpose, target DB/env, relationship to the rest of the codebase) so AI agents have the same picture.

`bin/deploy.sh` deliberately leaves first-time server start to the operator (echoes the manual command instead of forking a new process) so the script stays agnostic to the existing screen / tmux / nohup wrapping. When Puma is already running, it triggers a graceful reload via `tmp/restart.txt` (`config/puma.rb` already declares `plugin :tmp_restart`). It uses `git pull --ff-only` so any local uncommitted change or non-fast-forward divergence aborts the deploy cleanly.

## Key changes by commit

1. `docs: document utility scripts and Docker composition in CLAUDE.md`
2. `chore: add bin/deploy.sh for manual host deployments`

## Test plan

- [x] `bash -n bin/deploy.sh` passes (syntax check)
- [x] `bin/deploy.sh` is committed with execute permission (`100755`)
- [x] CLAUDE.md renders correctly on GitHub
- [ ] On the Pi: dry run reaches "Deploy done" without state changes when origin/master has no new commits
- [ ] On the Pi: confirm `git pull --ff-only` exits non-zero when there is a local uncommitted change
- [ ] On the Pi: confirm Puma reload via `tmp/restart.txt` after deployment when the server is already running

Made with [Cursor](https://cursor.com)