### PR TITLE
docs: document bin/deploy.sh in README and README_ja

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,16 @@ docker-compose up
 # api: `curl localhost:8080/blacklist` (see https://github.com/revsystem/sisito-api#api)
 ```
 
+### Updating an existing deployment
+
+For hosts that run Sisito directly (without Docker), use the bundled `bin/deploy.sh` helper to pull the latest `master`, install gems, precompile assets, and gracefully restart Puma:
+
+```console
+./bin/deploy.sh
+```
+
+The script aborts on uncommitted local changes or non-fast-forward divergence, and warns when there are pending database migrations (which should be applied manually during a maintenance window). It defaults to `RAILS_ENV=development` to match the typical single-host operation; override with `RAILS_ENV=production ./bin/deploy.sh` if your production environment is properly configured. See the comments at the top of `bin/deploy.sh` for details.
+
 ## Recommended System Requirements
 
 * Ruby 3.4+ (version 3.4.9 pinned via `mise.toml`)

--- a/README_ja.md
+++ b/README_ja.md
@@ -39,6 +39,16 @@ docker-compose up
 # API: `curl localhost:8080/blacklist` (詳細は https://github.com/revsystem/sisito-api#api 参照)
 ```
 
+### 既存ホストの更新
+
+Docker を使わずに Sisito を直接稼働させているホストでは、付属の `bin/deploy.sh` を使うと、`master` の取得・gem の install・アセットのプリコンパイル・Puma の graceful restart を一括で実行できます。
+
+```console
+./bin/deploy.sh
+```
+
+スクリプトはローカルに未コミットの差分や fast-forward できない分岐がある場合は中断します。未適用のマイグレーションがある場合も警告だけ表示し、自動では適用しません（メンテナンスウィンドウで手動適用してください）。`RAILS_ENV` の既定値は単一ホスト運用に合わせて `development` です。本物の production 環境がきちんと構成されている場合は `RAILS_ENV=production ./bin/deploy.sh` のように上書きしてください。詳細は `bin/deploy.sh` 冒頭のコメントを参照してください。
+
 ## 推奨システム要件
 
 * Ruby 3.4+（`mise.toml` で 3.4.9 を固定）


### PR DESCRIPTION
## Summary

- Add a short **Updating an existing deployment** section to both `README.md` and `README_ja.md`, placed right after the Docker block.
- Documents `bin/deploy.sh` (introduced in #13) so operators of non-Docker hosts can discover it from the entry-point documentation rather than only from `CLAUDE.md` or the script's own header comments.
- Notes the script's safety behavior (aborts on uncommitted changes / non-fast-forward, only warns on pending migrations) and the `RAILS_ENV=development` default.

Follow-up to #12 / #13. README-only change; no code or behavior changes.

## Test plan

- [x] `git diff` reviewed; only `README.md` and `README_ja.md` changed (10 + 10 lines).
- [x] Section placed after the existing **Using docker** / **Dockerを使用する場合** block, before **Recommended System Requirements** / **推奨システム要件**, keeping installation/update content grouped.
- [ ] Render preview verified on GitHub once the PR is open.

Made with [Cursor](https://cursor.com)