### PR TITLE
refactor(db): cleanup redundant performance indexes via dedicated migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,8 +98,11 @@ bundle exec rails db:migrate:status
 - **SessionsController** (`/auth/:provider/callback`): Google OAuth2 callback handling
 
 ### Database Schema (bounce_mails, whitelist_mails)
-- Current `db/schema.rb` is at version `2022_10_15_175608` (ActiveRecord::Schema[7.1])
-- Two additional performance index migrations exist in `db/migrate/` (20250705*) but are **not yet reflected** in `schema.rb` — run `db:migrate` to apply
+- Current `db/schema.rb` is at version `2026_04_25_000001` (ActiveRecord::Schema[7.2])
+- Three performance index migrations are reflected in `schema.rb`:
+  - `20250705000001_add_performance_indexes_to_bounce_mails` — original revision that added 11 composite indexes (kept as-is for history; most of these are dropped by the cleanup migration below)
+  - `20250705000002_add_addresseralias_optimization_indexes` — original revision that added 3 partial indexes (`where: ...`); MySQL silently drops the predicate so these became plain BTREE indexes that duplicate two of the 20250705000001 indexes
+  - `20260425000001_cleanup_redundant_performance_indexes` — **idempotent** cleanup that drops the 10 redundant/unused indexes from the two migrations above and ensures the 4 indexes that the controllers actually use exist (`idx_timestamp_addresser`, `idx_reason_timestamp`, `idx_recipient_senderdomain_timestamp`, `idx_reason_destination`). Safe to run on hosts where the earlier migrations were applied (full set), partially cleaned up by hand (the Pi case), or never applied at all
 
 ## Configuration
 
@@ -154,7 +157,7 @@ ruby update-sisto-db.rb /var/spool/sisito/mail
 ```
 
 ### `monitor_performance.rb`
-Standalone MySQL performance monitor. Reports running queries (>5s), table size and index ratio for `bounce_mails`, presence of the three performance indexes (`idx_timestamp_addresser`, `idx_reason_destination`, `idx_recipient_senderdomain_timestamp`), and key InnoDB memory variables (`innodb_buffer_pool_size`, `tmp_table_size`, `sort_buffer_size`). Runs against `sisito_development` by default — edit the connection block when targeting other environments.
+Standalone MySQL performance monitor. Reports running queries (>5s), table size and index ratio for `bounce_mails`, presence of the four performance indexes left after the cleanup migration `20260425000001` (`idx_timestamp_addresser`, `idx_reason_timestamp`, `idx_recipient_senderdomain_timestamp`, `idx_reason_destination`), and key InnoDB memory variables (`innodb_buffer_pool_size`, `tmp_table_size`, `sort_buffer_size`). Runs against `sisito_development` by default — edit the connection block when targeting other environments.
 
 ```bash
 ruby monitor_performance.rb
@@ -206,7 +209,7 @@ Mailcatcher's web UI is exposed on host port `11080` from the `sisito` container
 ## Important Gotchas
 
 1. **`eval` in initializer**: `config/initializers/sisito.rb` uses `eval()` on the `blacklisted_label_filter` YAML value — never accept untrusted YAML
-2. **Schema version lag**: `db/schema.rb` version (2022_10_15) does not include 20250705 performance index migrations — verify migration status with `bundle exec rails db:migrate:status`
+2. **MySQL ignores partial indexes**: `add_index ..., where: ...` in Rails compiles to plain `CREATE INDEX` on MySQL (the `WHERE` predicate is silently dropped). Migration `20250705000002` was written under the assumption it would be honored; the resulting full indexes ended up duplicating two of the `20250705000001` indexes, which is why `20260425000001` cleans them up
 3. **Stale test**: The only controller test references a non-existent route — needs to be fixed before adding test CI
 4. **Session typo**: `session[:pervious_url]` is used throughout — changing it would require updating all references
 5. **No Makefile**: Use `bundle exec rails` and `docker-compose` commands directly

--- a/db/migrate/20260425000001_cleanup_redundant_performance_indexes.rb
+++ b/db/migrate/20260425000001_cleanup_redundant_performance_indexes.rb
@@ -1,0 +1,69 @@
+class CleanupRedundantPerformanceIndexes < ActiveRecord::Migration[7.2]
+  # The two `20250705` performance index migrations together added 14
+  # composite indexes to bounce_mails. Reviewing the queries in
+  # app/controllers (StatsController, BounceMailsController, AdminController,
+  # WhitelistMailsController) showed that only 4 of those 14 are actually
+  # used; the other 10 are either redundant with an existing prefix index
+  # already in db/schema.rb, or referenced from no query at all.
+  #
+  # MySQL 8 does not support partial indexes (the `WHERE` predicate in
+  # `add_index ..., where: ...` is silently dropped at CREATE INDEX time),
+  # so the 3 partial indexes added by 20250705000002 ended up as plain
+  # BTREE indexes that duplicated 2 of the 20250705000001 indexes. That is
+  # why this migration removes both the original-name and the partial-name
+  # variants under `if_exists: true`.
+  #
+  # Kept indexes (verified against actual queries):
+  #   * idx_timestamp_addresser              StatsController date range +
+  #                                          addresser filter
+  #   * idx_reason_timestamp                 BounceMailsController /
+  #                                          AdminController reason filter
+  #   * idx_recipient_senderdomain_timestamp History pages
+  #                                          (BounceMailsController#show,
+  #                                           AdminController#show,
+  #                                           WhitelistMailsController#show)
+  #   * idx_reason_destination               StatsController#bounced_by_type
+  #
+  # The up step is intentionally idempotent (`if_exists` / `if_not_exists`)
+  # so it can converge regardless of which subset of indexes happens to
+  # exist on a given host (e.g. on the Pi, idx_addresseralias,
+  # idx_addresser_recipient, and idx_reason_destination had already been
+  # dropped manually at some point in the past).
+  REDUNDANT_INDEX_NAMES = %w[
+    idx_addresser_timestamp
+    idx_addresser_reason_timestamp
+    idx_recipient_senderdomain_join
+    idx_hardbounce_timestamp
+    idx_destination_timestamp
+    idx_addresseralias
+    idx_addresseralias_not_null
+    idx_addresseralias_recipient_valid
+    idx_addresser_recipient
+    idx_addresser_recipient_fallback
+  ].freeze
+
+  KEPT_INDEXES = [
+    [[:timestamp, :addresser],                'idx_timestamp_addresser'],
+    [[:reason, :timestamp],                   'idx_reason_timestamp'],
+    [[:recipient, :senderdomain, :timestamp], 'idx_recipient_senderdomain_timestamp'],
+    [[:reason, :destination],                 'idx_reason_destination']
+  ].freeze
+
+  def up
+    REDUNDANT_INDEX_NAMES.each do |name|
+      remove_index :bounce_mails, name: name, if_exists: true
+    end
+
+    KEPT_INDEXES.each do |columns, name|
+      add_index :bounce_mails, columns, name: name, if_not_exists: true
+    end
+  end
+
+  def down
+    # Reversing this migration would mean recreating the 10 dropped
+    # indexes that were never used and (for the partial ones) cannot be
+    # reproduced under MySQL anyway. Refuse rather than silently produce
+    # a different state.
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2022_10_15_175608) do
-  create_table "bounce_mails", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+ActiveRecord::Schema[7.2].define(version: 2026_04_25_000001) do
+  create_table "bounce_mails", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.datetime "timestamp", precision: nil, null: false
     t.string "lhost", null: false
     t.string "rhost", null: false
@@ -41,13 +41,17 @@ ActiveRecord::Schema[7.1].define(version: 2022_10_15_175608) do
     t.index ["digest"], name: "idx_digest"
     t.index ["hardbounce", "recipient"], name: "idx_hardbounce_recipient"
     t.index ["messageid"], name: "idx_messageid"
+    t.index ["reason", "destination"], name: "idx_reason_destination"
     t.index ["reason", "recipient"], name: "idx_reason_recipient"
+    t.index ["reason", "timestamp"], name: "idx_reason_timestamp"
+    t.index ["recipient", "senderdomain", "timestamp"], name: "idx_recipient_senderdomain_timestamp"
     t.index ["recipient"], name: "idx_recipient"
     t.index ["senderdomain"], name: "idx_senderdomain"
+    t.index ["timestamp", "addresser"], name: "idx_timestamp_addresser"
     t.index ["timestamp"], name: "idx_timestamp"
   end
 
-  create_table "whitelist_mails", id: :integer, charset: "utf8mb3", force: :cascade do |t|
+  create_table "whitelist_mails", id: :integer, charset: "utf8mb3", collation: "utf8mb3_general_ci", force: :cascade do |t|
     t.string "recipient", default: "", null: false
     t.string "senderdomain", default: "", null: false
     t.string "digest", null: false
@@ -57,5 +61,4 @@ ActiveRecord::Schema[7.1].define(version: 2022_10_15_175608) do
     t.index ["digest"], name: "index_whitelist_mails_on_digest"
     t.index ["recipient", "senderdomain"], name: "idx_recipient_senderdomain", unique: true
   end
-
 end

--- a/monitor_performance.rb
+++ b/monitor_performance.rb
@@ -64,8 +64,9 @@ class SisitoPerformanceMonitor
     puts "【重要インデックス状況】"
     indexes = [
       'idx_timestamp_addresser',
-      'idx_reason_destination', 
-      'idx_recipient_senderdomain_timestamp'
+      'idx_reason_timestamp',
+      'idx_recipient_senderdomain_timestamp',
+      'idx_reason_destination'
     ]
     
     indexes.each do |idx|


### PR DESCRIPTION
## Summary

The two `20250705` performance index migrations defined **14 indexes** in total on `bounce_mails`, but only **4** are actually used by any query in `app/controllers`. The rest are either redundant with an existing prefix index already in `db/schema.rb`, or referenced from no query at all. On top of that, MySQL silently drops the `WHERE` predicate from `add_index ..., where: ...`, so the 3 partial indexes from `20250705000002` ended up as plain BTREE indexes that duplicated two of the `20250705000001` indexes.

On the Pi, the database happened to be in a partially-cleaned-up state (both `20250705` migrations recorded as applied in `schema_migrations`, but `idx_addresseralias`, `idx_addresser_recipient`, and `idx_reason_destination` had been dropped by hand at some point in the past). A new dedicated cleanup migration converges every host (fresh, fully-applied, or hand-cleaned) to the same final state.

### Index review (per actual use)

**Kept (4):**

| Index | Used by |
| --- | --- |
| `idx_timestamp_addresser` | `StatsController` (date range + addresser filter, 4 queries) |
| `idx_reason_timestamp` | `BounceMailsController#index`, `AdminController#index` (`where(reason:)`) |
| `idx_recipient_senderdomain_timestamp` | `BounceMailsController#show`, `AdminController#show`, `WhitelistMailsController#show` (history) |
| `idx_reason_destination` | `StatsController#bounced_by_type` (`group(:reason, :destination).count`) |

**Dropped from `20250705000001` (5):**

`idx_addresser_timestamp`, `idx_addresser_reason_timestamp`, `idx_recipient_senderdomain_join`, `idx_hardbounce_timestamp`, `idx_destination_timestamp` — either redundant with an existing prefix index, or no query references them.

**Dropped from `20250705000002` (3 partial-but-actually-plain indexes):**

`idx_addresseralias_not_null`, `idx_addresseralias_recipient_valid`, `idx_addresser_recipient_fallback`. Their `WHERE` predicates don't survive on MySQL, and no query references them.

**Also dropped under `if_exists` for safety:** `idx_addresseralias`, `idx_addresser_recipient` (already missing on the Pi, listed so a fresh host that goes through `20250705000001` → `20250705000002` → `20260425000001` converges to the same state).

## Changes

- **Add `db/migrate/20260425000001_cleanup_redundant_performance_indexes.rb`**
  - Idempotent (`remove_index ... if_exists: true` / `add_index ... if_not_exists: true`).
  - Drops 10 redundant or unused indexes, ensures the 4 kept indexes exist.
  - `down`: `ActiveRecord::IrreversibleMigration` (the dropped partial indexes can't be recreated faithfully under MySQL).
- **Leave `20250705000001` and `20250705000002` untouched** — kept for history; their net effect is undone by the new cleanup migration.
- **Regenerate `db/schema.rb`** to `version: 2026_04_25_000001` (also picks up the Rails 7.2 schema header bump and the explicit `collation: "utf8mb3_general_ci"`).
- **Update `monitor_performance.rb`** to track the 4 kept indexes (was 3).
- **Update `CLAUDE.md`**
  - Database Schema section now lists the three migrations and their net effect.
  - Drop the now-resolved "Schema version lag" Gotcha.
  - Add a new Gotcha about MySQL silently dropping the `WHERE` predicate of `add_index`.

## Test plan

- [x] `mise exec -- ruby -c db/migrate/20260425000001_cleanup_redundant_performance_indexes.rb` → `Syntax OK`.
- [x] Pi (`RAILS_ENV=development`):
  - [x] `bundle exec rails db:migrate:status` shows `20260425000001` as `down` before applying.
  - [x] `bundle exec rails db:migrate` applies `20260425000001` cleanly.
  - [x] `ruby monitor_performance.rb` shows all 4 indexes as ✅ 作成済み.
  - [x] `SHOW INDEX FROM bounce_mails WHERE Key_name LIKE 'idx_%'` lists exactly the 9 pre-existing + 4 kept indexes; all redundant indexes are gone.
  - [x] `bundle exec rails db:schema:dump` regenerates `db/schema.rb` to `version: 2026_04_25_000001`; the regenerated file is committed in this PR.

Made with [Cursor](https://cursor.com)