### PR TITLE
chore/docs: ignore public/assets/ and fix outdated performance index docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ db/*.sqlite3
 /doc/app/
 /doc/features.html
 /doc/specs.html
+/public/assets/
 /public/cache
 /public/stylesheets/compiled
 /public/system/*


### PR DESCRIPTION
## Summary

- Add `/public/assets/` to `.gitignore` — generated by `assets:precompile` in `bin/deploy.sh` but was not previously gitignored
- Fix outdated performance index documentation in README and README_ja

Note: `bundle/` (which also appeared as untracked on Pi) was caused by a stale `.bundle/config` with `BUNDLE_PATH: "bundle"` left over from earlier development iterations. That setting has been removed on Pi; no `.gitignore` entry is needed since the correct deployment path (`vendor/bundle/`) is already covered.

### README / README_ja fixes

The "Performance Indexes Applied" section was written before the cleanup migration (`20260425000001`) was added and listed indexes that no longer exist after `db:migrate`:

- Removed: `idx_addresseralias_recipient_valid`, `idx_addresser_recipient_fallback` (dropped by cleanup migration)
- Added: `idx_reason_timestamp` (was missing)
- Reformatted as a table showing columns and which controller uses each index
- Added a sentence after Step 3 explaining the 3-migration sequence
- Fixed rollback step count: `STEP=2` → `STEP=3`

## Test plan

- [x] `git ls-files | grep public/assets` returns nothing (directory not tracked)
- [x] `git status` on Pi shows no untracked files after deploy
- [x] Index table matches `db/schema.rb` and `20260425000001` cleanup migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)