### PR TITLE
docs: fix outdated performance index info in README and README_ja

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ bundle exec rails db:migrate
 mysql -u root -p sisito_production -e "SHOW FULL PROCESSLIST;"
 ```
 
+Three migrations run in sequence. The first two add composite indexes; the third (cleanup) removes the redundant ones and leaves only the four indexes that the application actually uses.
+
 #### Step 4: Verify Index Creation
 
 ```bash
@@ -320,13 +322,16 @@ mysql -u root -p sisito_production -e "SHOW FULL PROCESSLIST;"
 
 ### Performance Indexes Applied
 
-The following specialized indexes are added for large dataset performance:
+After running `db:migrate`, the following four indexes exist on `bounce_mails`:
 
-* `idx_timestamp_addresser` - Date range analytics queries
-* `idx_reason_destination` - Statistical GROUP BY operations
-* `idx_recipient_senderdomain_timestamp` - Complex filtering and JOINs
-* `idx_addresseralias_recipient_valid` - Conditional indexing for sender statistics
-* `idx_addresser_recipient_fallback` - Fallback queries optimization
+| Index | Columns | Used by |
+|-------|---------|---------|
+| `idx_timestamp_addresser` | `timestamp, addresser` | StatsController date-range queries |
+| `idx_reason_timestamp` | `reason, timestamp` | BounceMailsController / AdminController reason filter |
+| `idx_recipient_senderdomain_timestamp` | `recipient, senderdomain, timestamp` | History pages and whitelist JOINs |
+| `idx_reason_destination` | `reason, destination` | StatsController bounce-type statistics |
+
+No table columns are added or removed; only indexes change.
 
 ### Expected Performance Improvements
 
@@ -346,7 +351,7 @@ The following specialized indexes are added for large dataset performance:
 mysql -u root -p sisito_production < backup_sisito_YYYYMMDD_HHMMSS.sql
 
 # 2. Rollback migrations
-bundle exec rails db:rollback STEP=2
+bundle exec rails db:rollback STEP=3
 
 # 3. Restart application
 bundle exec rails server

--- a/README_ja.md
+++ b/README_ja.md
@@ -247,6 +247,8 @@ bundle exec rails db:migrate
 mysql -u root -p sisito_production -e "SHOW FULL PROCESSLIST;"
 ```
 
+3本のマイグレーションが順に実行されます。最初の2本で複合インデックスが追加され、3本目（クリーンアップ）で重複インデックスが削除されます。最終的にアプリケーションが実際に使用する4本のインデックスだけが残ります。
+
 #### ステップ4: インデックス作成の確認
 
 ```bash
@@ -267,13 +269,16 @@ mysql -u root -p sisito_production -e "SHOW FULL PROCESSLIST;"
 
 ### 適用されるパフォーマンスインデックス
 
-大規模データセットのパフォーマンス向上のため、以下の専用インデックスが追加されます：
+`db:migrate` 実行後、`bounce_mails` テーブルに以下の4本のインデックスが存在します：
 
-* `idx_timestamp_addresser` - 日付範囲分析クエリ用
-* `idx_reason_destination` - 統計GROUP BY操作用
-* `idx_recipient_senderdomain_timestamp` - 複雑なフィルタリングとJOIN用
-* `idx_addresseralias_recipient_valid` - 送信者統計用条件付きインデックス
-* `idx_addresser_recipient_fallback` - フォールバッククエリ最適化用
+| インデックス | カラム | 使用箇所 |
+|-------------|--------|---------|
+| `idx_timestamp_addresser` | `timestamp, addresser` | StatsController 日付範囲クエリ |
+| `idx_reason_timestamp` | `reason, timestamp` | BounceMailsController / AdminController バウンス理由フィルタ |
+| `idx_recipient_senderdomain_timestamp` | `recipient, senderdomain, timestamp` | 履歴ページ・ホワイトリストJOIN |
+| `idx_reason_destination` | `reason, destination` | StatsController バウンス種別統計 |
+
+テーブルのカラム追加・削除はありません。インデックスのみが変更されます。
 
 ### 期待されるパフォーマンス改善
 
@@ -293,7 +298,7 @@ mysql -u root -p sisito_production -e "SHOW FULL PROCESSLIST;"
 mysql -u root -p sisito_production < backup_sisito_YYYYMMDD_HHMMSS.sql
 
 # 2. マイグレーションをロールバック
-bundle exec rails db:rollback STEP=2
+bundle exec rails db:rollback STEP=3
 
 # 3. アプリケーションを再起動
 bundle exec rails server


### PR DESCRIPTION
## Summary

- Fix the "Performance Indexes Applied" section which listed indexes removed by the cleanup migration (`20260425000001`)
- Add a note after Step 3 explaining the 3-migration sequence
- Fix rollback step count: `STEP=2` → `STEP=3`

### Detail

The section was written before the cleanup migration was introduced and contained two indexes that no longer exist after `db:migrate`:

- Removed: `idx_addresseralias_recipient_valid`, `idx_addresser_recipient_fallback` (dropped by cleanup migration)
- Added: `idx_reason_timestamp` (was missing from the list)
- Reformatted as a table showing columns and which controller uses each index
- Added a clarifying note that only indexes change (no column additions or removals)

## Test plan

- [x] Index table matches `db/schema.rb` and the surviving indexes from `20260425000001`
- [x] Rollback step count matches the number of migrations (3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)