### PR TITLE
chore(deps): bump crass to 1.0.7 to resolve bundler-audit advisories

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,7 +101,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
-    crass (1.0.6)
+    crass (1.0.7)
     csv (3.3.5)
     dartsass-sprockets (3.2.1)
       railties (>= 4.0.0)


### PR DESCRIPTION
Closes #20

## What

`bundle update crass` to clear four DoS advisories flagged by `bundler-audit` on `master`.

| Gem | Before | After |
|---|---|---|
| crass | 1.0.6 | 1.0.7 |

`crass` is transitive (loofah -> rails-html-sanitizer -> Rails); loofah's `crass ~> 1.0.2` already allows 1.0.7, so only `Gemfile.lock` changes. No Gemfile / application code changes.

## Advisories resolved (all DoS, Unknown criticality)

- GHSA-6jxj-px6v-747w — deeply nested CSS -> SystemStackError / memory
- GHSA-6wmf-3r64-vcwv — large numeric exponents -> CPU/memory DoS
- GHSA-8vfg-2r28-hvhj — non-ASCII -> superlinear CPU
- GHSA-wwpr-jff3-395c — many adjacent comments -> SystemStackError

## Verification

- `bundle-audit check --update` -> **No vulnerabilities found** (exit 0)
- `bundle check` -> dependencies satisfied

🤖 Generated with [Claude Code](https://claude.com/claude-code)