### PR TITLE
chore(deps): bump websocket-driver to 0.8.2 to resolve bundler-audit advisories

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -335,7 +335,7 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
-    websocket-driver (0.8.0)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)


### PR DESCRIPTION
Closes #22

## What

`bundle update websocket-driver` to clear four advisories flagged by `bundler-audit` on `master`.

| Gem | Before | After |
|---|---|---|
| websocket-driver | 0.8.0 | 0.8.2 |

`websocket-driver` is transitive (actioncable -> Rails); actioncable's `websocket-driver >= 0.6.1` already allows 0.8.2, so only `Gemfile.lock` changes. No Gemfile / application code changes.

## Advisories resolved (Unknown criticality)

- CVE-2026-54463 / GHSA-ghhp-3qvg-889p — memory exhaustion via abuse of protocol length headers
- CVE-2026-54464 / GHSA-33ph-fccm-39pj — resource limit bypass via message compression
- CVE-2026-54465 / GHSA-8j3g-f24p-4mpw — memory exhaustion in HTTP header parser
- GHSA-2x63-gw47-w4mm — denial of service via malformed Host header

## Verification

- `bundle-audit check --update` -> **No vulnerabilities found** (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CHTijKeYuNgopzbrUC9VjG

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level transitive dependency bump with no application changes; typical low-risk security maintenance.
> 
> **Overview**
> Bumps the locked **websocket-driver** version from **0.8.0** to **0.8.2** in `Gemfile.lock` only; no `Gemfile` or application code changes.
> 
> The update is transitive through **actioncable** (Rails) and addresses several **bundler-audit** advisories (memory exhaustion, compression bypass, HTTP header parsing, and malformed Host header DoS).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19a54e19cc787bc70e6c8d3cf0a4c47bd7c9177e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->