### PR TITLE
Load update-sisto-db.rb's sisimai via project Bundler instead of a system gem

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,7 +163,7 @@ These scripts live at the repository root (not under `bin/`) and are invoked man
 Sisimai-based bounce ingestion script. Reads bounce emails from a Maildir-style directory (passed as the first argv), parses them with `Sisimai.rise`, and inserts each result into `bounce_mails`. Connects directly to MySQL (`bounce` / `bounce` / `sisito_development`) without going through ActiveRecord, so timestamps are stored via `FROM_UNIXTIME(...)` and the `digest` column is populated with `SHA1(recipient)`. The Postfix container's `/collect.rb` is a similar in-container variant.
 
 ```bash
-ruby update-sisto-db.rb /var/spool/sisito/mail
+mise exec -- ruby update-sisto-db.rb /var/spool/sisito/mail
 ```
 
 ### `monitor_performance.rb`

--- a/update-sisto-db.rb
+++ b/update-sisto-db.rb
@@ -1,4 +1,6 @@
 #!/usr/bin/env ruby
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('Gemfile', __dir__)
+require 'bundler/setup'
 require 'fileutils'
 require 'sisimai'
 require 'mysql2'


### PR DESCRIPTION
## Summary

- `update-sisto-db.rb` now sets `BUNDLE_GEMFILE` relative to `__dir__` (same pattern as `config/boot.rb`) and calls `require 'bundler/setup'` before requiring sisimai/mysql2, so it always uses the versions pinned in Gemfile.lock (sisimai 5.7.1) regardless of which system-wide gems happen to be installed. Running without `mise exec --` now fails fast with `Could not find sisimai-5.7.1 in locally installed gems` instead of silently falling back to a stale system gem.
- Updated CLAUDE.md's invocation example and the `sisito-deploy` skill's prerequisites/troubleshooting notes to match.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to a standalone ingestion script and docs; improves gem version consistency with no auth or schema impact.
> 
> **Overview**
> The root bounce-ingestion script **`update-sisto-db.rb`** now bootstraps Bundler the same way as **`config/boot.rb`**: it sets **`BUNDLE_GEMFILE`** to the repo **`Gemfile`** and **`require`s `bundler/setup`** before loading **`sisimai`** and **`mysql2`**, so runs use **`Gemfile.lock`** versions instead of whatever system gems are installed.
> 
> **`CLAUDE.md`**’s example invocation is updated to **`mise exec -- ruby update-sisto-db.rb …`**, reflecting that the script expects the project bundle to be available (missing locked gems fail fast rather than silently using a stale system **`sisimai`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b7e4c18bfbb797c00e79d581afac8ba0e4e1d6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->