### PR TITLE
test: add CI test harness, fix stale test, then fix etc double-count

### DIFF
--- a/.claude/docs/plans/2026-08-11-test-harness-and-etc-slice-fix-plan.md
+++ b/.claude/docs/plans/2026-08-11-test-harness-and-etc-slice-fix-plan.md
@@ -1,0 +1,447 @@
+# テスト基盤の整備と etc 二重計上の修正 実装計画
+
+日時: 2026-08-11
+深度: standard
+関連調査: [.claude/docs/research/2026-08-11-test-harness-and-etc-slice-fix-research.md](../research/2026-08-11-test-harness-and-etc-slice-fix-research.md)
+設計仕様: [.claude/docs/specs/2026-08-11-test-harness-and-etc-slice-fix-spec.md](../specs/2026-08-11-test-harness-and-etc-slice-fix-spec.md)
+
+## 概要
+
+自動テストが機能していない状態（#39）を解消し、その基盤の上で `etc` 二重計上バグ（#38）を修正する。GitHub Actions に MySQL 8.0 サービスコンテナ付きのテストジョブを追加し、`config/environments/test.rb` を Rails 7.2 準拠に直し、`bounce_mails` の fixtures と境界条件テストを新設したうえで、`StatsHelper#chart_columns` に `etc` の集計ロジックを1箇所に集約して6箇所のビューを置き換える。
+
+## アプローチ
+
+spec の残決定事項（論点1: B＝ヘルパー切り出し、論点2: A＝push to master + pull_request、論点3: B＝統合テストを追加）を前提とする。
+
+`chart_columns(collection, top: 3)` の実装は、research.md で確認した2つの罠を避ける設計にする。切り出しは `slice(top..-1)` ではなく `drop(top)` を使い（要素数によらず必ず `Array` を返す）、`etc` を出すかどうかの判定は `present?` ではなく `.empty?` で行う。残りの合計は `pairs.drop(top).sum` ではなく `pairs.drop(top).sum {|_, v| v }`（ペア配列のまま `sum` を呼ぶと `TypeError` になるため）。これにより、現行コードが `nil` 経由でしか担保できていなかった「対象が少ないときは `etc` を出さない」という契約を、境界（ちょうど3件）まで含めて明示的に担保する。
+
+CI は既存の `bundler-audit.yml` と同じ `ruby/setup-ruby@v1`（`mise.toml` から Ruby 3.4.9 を自動検出することを確認済み）を使い、別ワークフローファイルとして追加する。データベースは `db:schema:load` に固定し `db:migrate` は使わない。`db/migrate/20170128144003_example_data.rb` が `Date.today - rand(14).days` で非決定的なデータを投入するためで、`db:schema:load` はこのマイグレーションの内容を実行せず、バージョン番号だけを「migrated 済み」として記録するため `maintain_test_schema!` の `PendingMigrationError` も起きない(research.md で activerecord 7.2.3.2 のソースを読んで確認済み)。
+
+## 変更内容
+
+### 変更1: test 環境の show_exceptions 修正
+
+対象: `config/environments/test.rb`
+
+```ruby
+# 変更前
+  config.action_dispatch.show_exceptions = false
+
+# 変更後
+  config.action_dispatch.show_exceptions = :none
+```
+
+`false` は actionpack 7.2.3.2 の `ExceptionWrapper#show?` の case 式で `else` に落ち、「例外を表示する」（re-raise しない）と解釈される。`:none` にすることで、テスト内の例外が Minitest にそのまま伝播する。
+
+### 変更2: GitHub Actions テストジョブの追加
+
+対象: `.github/workflows/test.yml`（新規）
+
+```yaml
+name: test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: sisito_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+    env:
+      RAILS_ENV: test
+      DISABLE_SPRING: 1
+      DATABASE_URL: mysql2://root@127.0.0.1:3306/sisito_test
+      TZ: UTC
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Prepare test database
+        run: bin/rails db:create db:schema:load
+      - name: Run tests
+        run: bin/rails test
+```
+
+`DATABASE_URL` で `127.0.0.1` を明示するのは、`config/database.yml` の test ブロックが `host: localhost` を指しており、MySQL クライアントライブラリ（mysql2 gem が使う libmysqlclient）は慣習的に `localhost` を Unix ソケット接続の指示として扱うためである。GitHub Actions のサービスコンテナは TCP でしか到達できないため、`localhost` のままだと接続に失敗する可能性がある。`DATABASE_URL` を設定すると Rails はその環境の接続情報を `database.yml` より優先して使うため、コミット済みの `database.yml` 自体は変更しない。この振る舞いは CI を初めて走らせたときに実地で確認する。
+
+`TZ: UTC` は fixtures の日時文字列（変更3）を意図どおりの時刻として保存させるための必須設定であり、任意の防御策ではない。research.md で実測したとおり、fixtures YAML のオフセット無し日時文字列は、それをパースするプロセスの `TZ` によって実際に格納される時刻が変わる（`config.active_record.default_timezone = :local` のため、Psych がプロセスのローカルタイムゾーンで解釈した `Time` がそのまま `getlocal` 経由で SQL に書き込まれる）。GitHub Actions の `ubuntu-latest` は既定で UTC だが、これはランナーイメージの既定値であり実装が依存してよい契約ではないため、明示的に `TZ: UTC` を宣言し、fixtures の日時文字列を UTC 前提の値として書く。
+
+`DISABLE_SPRING=1` は、`bin/rails` が `bin/spring` を経由する構成になっており(`config/spring.rb` あり)、CI の使い捨てコンテナで Spring デーモンを起動させないための保険。Pi で Spring がキャッシュを持ち越して混乱した経緯(CLAUDE.md の Gotcha 9)があるため、CI では最初から無効化する。
+
+`--health-cmd` を設定すると GitHub Actions がサービスコンテナのヘルスチェック成功を待ってからジョブのステップを開始するため、明示的な待機ループは不要。
+
+トリガーは push to master と pull_request の2つ（spec 論点2の回答 A）。bundler-audit にある weekly cron は含めない。
+
+### 変更3: `BounceMail.within_period` の境界条件テスト
+
+対象: `test/fixtures/bounce_mails.yml`（新規）
+
+共通デフォルトは Rails fixtures 組み込みの `DEFAULTS` キー（大文字。`ActiveRecord::FixtureSet` が無条件に無視する予約名）をアンカーにする。トップレベルに自作のダミーキーを作らない(research.md で確認した Rails 標準の回避策)。
+
+```yaml
+DEFAULTS: &DEFAULTS
+  lhost: mail.example.com
+  rhost: mail.test1.example.com
+  alias: default@test1.example.com
+  listid: ""
+  reason: userunknown
+  action: failed
+  subject: hello
+  messageid: default@xxx.mail
+  smtpagent: MTA::Postfix
+  hardbounce: false
+  smtpcommand: RCPT
+  destination: test1.example.com
+  senderdomain: example.com
+  feedbacktype: ""
+  diagnosticcode: "550 no such user"
+  deliverystatus: "5.0.0"
+  timezoneoffset: "+0900"
+  addresser: no-reply@example.com
+  addresseralias: ""
+  digest: ""
+
+boundary_start:
+  <<: *DEFAULTS
+  timestamp: 2026-08-01 00:00:00
+  recipient: boundary_start@test1.example.com
+
+day_before_start:
+  <<: *DEFAULTS
+  timestamp: 2026-07-31 23:59:59
+  destination: excluded-before.example.com
+  recipient: day_before_start@excluded-before.example.com
+
+boundary_end:
+  <<: *DEFAULTS
+  timestamp: 2026-08-02 23:59:59
+  reason: filtered
+  destination: test2.example.com
+  recipient: boundary_end@test2.example.com
+
+boundary_next_day:
+  <<: *DEFAULTS
+  timestamp: 2026-08-03 00:00:00
+  destination: excluded-after.example.com
+  recipient: boundary_next_day@excluded-after.example.com
+```
+
+固定の過去日付（2026-08-01/02）を使う。`Date.today` に依存する値は一切含めない。`boundary_start` は `from` の00:00:00（下限を含む）、`boundary_end` は `to` の23:59:59(上限を含む)、`day_before_start` と `boundary_next_day` はそれぞれ範囲の外側1秒・1マイクロ秒相当の外側にあり、除外されることを確認する。`boundary_start` と `boundary_end` は destination・reason を変えており、変更5の統合テストでも「範囲内が反映されること」の確認に流用する。
+
+これらの日時文字列はオフセット無しの YAML 日時として書いており、変更2 の CI ワークフローで `TZ: UTC` を設定していることが前提になる(research.md「fixtures の日時は CI ランナーの TZ に依存して意味が変わる」を参照)。`TZ` を設定しない、または UTC 以外にすると、境界条件テストが意図と異なる時刻を検証することになる。
+
+対象: `test/models/bounce_mail_test.rb`（新規）
+
+```ruby
+require "test_helper"
+
+class BounceMailTest < ActiveSupport::TestCase
+  test "within_period includes the start of the range at 00:00:00" do
+    result = BounceMail.within_period(Date.parse("2026-08-01"), Date.parse("2026-08-02"))
+    assert_includes result, bounce_mails(:boundary_start)
+  end
+
+  test "within_period includes the end of the range at 23:59:59" do
+    result = BounceMail.within_period(Date.parse("2026-08-01"), Date.parse("2026-08-02"))
+    assert_includes result, bounce_mails(:boundary_end)
+  end
+
+  test "within_period excludes the day before the range" do
+    result = BounceMail.within_period(Date.parse("2026-08-01"), Date.parse("2026-08-02"))
+    assert_not_includes result, bounce_mails(:day_before_start)
+  end
+
+  test "within_period excludes the day after the range" do
+    result = BounceMail.within_period(Date.parse("2026-08-01"), Date.parse("2026-08-02"))
+    assert_not_includes result, bounce_mails(:boundary_next_day)
+  end
+end
+```
+
+### 変更4: `StatsHelper#chart_columns` の追加
+
+対象: `app/helpers/stats_helper.rb`
+
+```ruby
+module StatsHelper
+  # セクション見出しに添える集計期間の表記。
+  # Recently Bounced は直下のフォームに from/to が出ているため対象外。
+  def stats_period_label(from, to)
+    "#{from.strftime('%Y-%m-%d')} 〜 #{to.strftime('%Y-%m-%d')}"
+  end
+
+  # 上位 top 件を個別系列、残り全件の合計を 'etc' として返す。
+  # 残りが空なら 'etc' 系列は追加しない（0 件の etc を出さない）。
+  # collection は Hash（key => count）または [key, count] のソート済み配列のどちらでもよい。
+  # 呼び出し元のコレクションは変更しない（drop/first はいずれも非破壊）。
+  def chart_columns(collection, top: 3)
+    pairs = collection.to_a
+    columns = pairs.first(top)
+    remainder = pairs.drop(top)
+    remainder.empty? ? columns : columns + [['etc', remainder.sum {|_, v| v }]]
+  end
+end
+```
+
+対象: `test/helpers/stats_helper_test.rb`（新規）
+
+```ruby
+require "test_helper"
+
+class StatsHelperTest < ActionView::TestCase
+  test "returns individual slices without an etc entry when nothing remains" do
+    assert_equal [["a", 5], ["b", 3], ["c", 1]], chart_columns({"a" => 5, "b" => 3, "c" => 1})
+  end
+
+  test "adds an etc entry summing everything past top" do
+    columns = chart_columns({"a" => 5, "b" => 3, "c" => 1, "d" => 1})
+    assert_equal [["a", 5], ["b", 3], ["c", 1], ["etc", 1]], columns
+  end
+
+  test "does not add an etc entry for fewer than top elements" do
+    assert_equal [["a", 5], ["b", 3]], chart_columns({"a" => 5, "b" => 3})
+  end
+
+  test "does not add an etc entry for an empty collection" do
+    assert_equal [], chart_columns({})
+  end
+
+  test "accepts an already-sorted array of pairs without mutating it" do
+    pairs = [["a", 5], ["b", 3], ["c", 1], ["d", 1]]
+    original = pairs.dup
+    chart_columns(pairs)
+    assert_equal original, pairs
+  end
+
+  test "respects a custom top" do
+    columns = chart_columns({"a" => 4, "b" => 3, "c" => 2, "d" => 1}, top: 2)
+    assert_equal [["a", 4], ["b", 3], ["etc", 3]], columns
+  end
+end
+```
+
+`chart_columns` 自体のテストは DB を使わないため fixtures に依存しない。0/1/2/3/4件という境界と、Hash/Array 両方の入力、非破壊性を直接カバーする。
+
+### 変更5: 6箇所のビューを `chart_columns` に置き換え
+
+対象: `app/views/stats/_recent_bounced.html.erb`
+
+```erb
+<%# 変更前（:72-77, :90-95 の2箇所、同型） %>
+<% if @count_by_destination.present? %>
+  <%= javascript_tag do %>
+    c3.generate({
+      bindto: '#count_by_destination',
+      size: {height: 300},
+      data: {
+        columns: <%= raw(
+          @count_by_destination.to_a.slice(0, 10)
+            .push(['etc', @count_by_destination.values.slice(3..-1).try(:sum)])
+            .select {|_, v| v.present? }
+            .inspect
+        ) %>,
+        type : 'pie'
+      }
+    });
+  <% end %>
+<% end %>
+
+<%# 変更後 %>
+<% if @count_by_destination.present? %>
+  <%= javascript_tag do %>
+    c3.generate({
+      bindto: '#count_by_destination',
+      size: {height: 300},
+      data: {
+        columns: <%= raw chart_columns(@count_by_destination).inspect %>,
+        type : 'pie'
+      }
+    });
+  <% end %>
+<% end %>
+```
+
+`@count_by_reason` も同じ形で置き換える。
+
+対象: `app/views/stats/_unique_recipient_bounced.html.erb`
+
+`@uniq_count_by_destination` / `@uniq_count_by_reason` / `@uniq_count_by_sender` の3箇所とも、`columns:` の中身を `<%= raw chart_columns(@uniq_count_by_X).inspect %>` に置き換える。`present?` ガードと `No data in this period.` の表示条件（#36 で追加済み）はそのまま残す。
+
+対象: `app/views/stats/_bounced_by_type.html.erb`
+
+```erb
+<%# 変更前 %>
+<% chunk.each do |reason, count_by_destination| %>
+  <% count_by_destination = count_by_destination.sort_by(&:last).reverse %>
+  <%= javascript_tag do %>
+    c3.generate({
+      bindto: '<%= "#bounced_by_#{reason}" %>',
+      data: {
+        columns: <%= raw(
+          count_by_destination.slice(0, 10)
+            .push(['etc', count_by_destination.map(&:last).slice(3..-1).try(:sum)])
+            .select {|_, v| v.present? }
+            .inspect
+        ) %>,
+        type : 'donut'
+      },
+      donut: {
+        title: '<%= reason %>',
+      }
+    });
+  <% end %>
+<% end %>
+
+<%# 変更後 %>
+<% chunk.each do |reason, count_by_destination| %>
+  <% count_by_destination = count_by_destination.sort_by(&:last).reverse %>
+  <%= javascript_tag do %>
+    c3.generate({
+      bindto: '<%= "#bounced_by_#{reason}" %>',
+      data: {
+        columns: <%= raw chart_columns(count_by_destination).inspect %>,
+        type : 'donut'
+      },
+      donut: {
+        title: '<%= reason %>',
+      }
+    });
+  <% end %>
+<% end %>
+```
+
+`count_by_destination` は Array（`[destination, count]` のソート済み配列）のまま `chart_columns` に渡す。`chart_columns` 内部で `.to_a` を呼んでも self が返るだけだが、`first`/`drop` はいずれも非破壊なので呼び出し元の変数は変更されない。
+
+### 変更6: stale テストの修正
+
+対象: `test/controllers/status_controller_test.rb`
+
+```ruby
+# 変更前
+require 'test_helper'
+
+class MonitorControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get monitor_index_url
+    assert_response :success
+  end
+
+end
+
+# 変更後
+require 'test_helper'
+
+class StatusControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get status_url
+    assert_response :success
+  end
+end
+```
+
+`StatusController#index` の集計窓は `Time.now` を都度計算するため、fixtures の固定過去日時は対象に入らない。ルーティングの是正と HTTP 200 のスモークに留め、JSON の中身は断言しない。
+
+### 変更7: `StatsController#index` の統合テスト
+
+対象: `test/controllers/stats_controller_test.rb`（新規）
+
+```ruby
+require "test_helper"
+
+class StatsControllerTest < ActionDispatch::IntegrationTest
+  test "reflects the given date range in the aggregation blocks" do
+    get root_path, params: { from: "2026-08-01", to: "2026-08-02" }
+
+    assert_response :success
+    assert_includes response.body, "2026-08-01 〜 2026-08-02"
+    assert_includes response.body, "test1.example.com"
+    assert_includes response.body, "test2.example.com"
+    assert_not_includes response.body, "excluded-before.example.com"
+    assert_not_includes response.body, "excluded-after.example.com"
+  end
+
+  test "shows No data in this period for a range with no bounces" do
+    get root_path, params: { from: "2020-01-01", to: "2020-01-02" }
+
+    assert_response :success
+    assert_includes response.body, "No data in this period."
+  end
+end
+```
+
+1本目は変更3の fixtures（`boundary_start` / `boundary_end` が範囲内、`day_before_start` / `boundary_next_day` が範囲外）をそのまま使う。期間ラベルの表示、範囲内destinationの反映、範囲外destinationの非表示を1つのリクエストで確認する。2本目は fixtures のどれとも重ならない固定の過去期間を指定し、空データ時の表示を確認する。「8チャートが描画される」ことをチャートの絶対数で数えるのではなく、期間フィルタが利いているかどうかを本文の文字列で確認する形にした(research.md で指摘したとおり、`bounced_by_type` は reason 数だけドーナツが増減するため絶対数のアサーションは不安定になる)。
+
+## 影響範囲
+
+既存テストへの影響: `status_controller_test.rb` は現在実行すれば `NameError` で落ちる状態なので、修正により初めて成立するようになる。他に既存の自動テストは無い。
+
+API 変更なし。ルーティングの変更もない。マイグレーションもない（`db/schema.rb` は変更しない）。
+
+`etc` 修正によりチャートの見た目が変わる。個別表示件数が10件から3件に減り、4〜10位だった項目は個別表示から消えて `etc` に吸収される。チャート合計の数値は二重計上が無くなり正しくなる。Issue #38 に記載済み。
+
+CI の実行時間が増える。既存の `bundler-audit`（約25秒）に加えて、MySQL サービスコンテナの起動・healthcheck 待ち・`bundle install`・`db:create db:schema:load`・`bin/rails test` が加わる。
+
+## 考慮事項
+
+`DATABASE_URL` による接続先の上書きは、`config/database.yml` を変更せずに CI 特有の接続問題（`host: localhost` のソケット優先解決）を避けるための処置であり、ローカル開発環境や Pi の挙動には影響しない。
+
+`DISABLE_SPRING=1` は CI 環境でのみ設定し、既存の `bin/spring` を使ったローカル開発・Pi のワークフローには影響しない。
+
+`TZ: UTC` も CI 環境でのみ設定する。Pi は TZ=Asia/Tokyo で動作しており(CLAUDE.md)、この設定はローカル開発・Pi の挙動を変えない。CI で `TZ` を明示するのは、fixtures の日時文字列が意図どおりの瞬間として保存されることを保証するためであり、technically な保険ではなく変更3の fixtures 設計が成立するための前提条件である。
+
+fixtures の日付（2026-08-01/02）は固定の過去日付であり、`Date.today` には一切依存しない。時間が経過してもこれらのテストの結果は変わらない。ただし、この決定性は `TZ: UTC` とセットで初めて成立する。`TZ` が未設定または UTC 以外だと、fixtures の日時文字列は同じ YAML のまま実際に格納される時刻が変わり得る(research.md で `TZ=UTC` / `TZ=Asia/Tokyo` / `TZ=America/Los_Angeles` それぞれで別の時刻・日付になることを実測済み)。
+
+`chart_columns` の変更によりビューの表示範囲は10件から3件に減るが、これは二重計上を直すために必須の変更ではなく、凡例を見やすくするための独立した選択（`first(N)` + `drop(N).sum` は N がいくつでも合計が一致するため）。research.md に経緯を記録済み。
+
+CI が初めて赤くなる可能性がある箇所は、`DATABASE_URL` 経由の接続、および `stats#index` の統合テストがレイアウト経由でアセットパイプライン（Sprockets + dartsass-sprockets）を要求する点。実装順序として、まず CI ワークフローと最小のテスト（`status_controller_test.rb` の修正、`bounce_mail_test.rb`）を先に通し、`test.yml` が緑になったことを確認してから `chart_columns` と6箇所のビュー修正・統合テストに進む。
+
+## 残決定事項
+
+無し。spec.md の残決定事項3件（B/A/B）で主要な設計判断は確定しており、本計画はその実行に必要な実装詳細を埋めるものにとどまる。CI の `DATABASE_URL` / `DISABLE_SPRING` は技術的なリスク回避であり、トレードオフを伴う選択ではないため、annotation サイクルでの判断事項としては挙げていない。
+
+## タスクリスト
+
+大区分は独立実装可能な「ユニット」でまとめる。ユニット A → B → C は順序依存があり並列不可（B はローカル変更だけでは検証できず、実際に CI を走らせて緑になることを確認する外部ゲートを含むため）。ユニット内のタスクは上から順に実施する。
+
+### ユニットA: test 環境の是正・fixtures・境界条件テスト・stale テスト修正（並列不可: 依存 = なし）
+
+CI に乗せる前にローカルで用意できるものをまとめる。ここまではファイル編集のみで、実行して確認することはできない（ローカルに MySQL が無いため）。
+
+- [x] A-1: `config/environments/test.rb` の `show_exceptions` を `:none` に修正する（変更1）
+- [x] A-2: `test/fixtures/bounce_mails.yml` を `DEFAULTS` アンカーを使う形で追加する（変更3）
+- [x] A-3: `test/models/bounce_mail_test.rb` を追加し、`within_period` の境界条件4点（下限含む・上限含む・前日除外・翌日除外）をテストする（変更3）
+- [x] A-4: `test/controllers/status_controller_test.rb` を `StatusControllerTest` / `status_url` に修正する（変更6）
+
+### ユニットB: CI ワークフローの追加とグリーン化確認（並列不可: 依存 = ユニットA）
+
+ここが唯一、ローカルでは検証できず実際に CI を走らせる必要があるゲート。ユニットC に進む前に、最小構成のテストで CI が通ることを確認する。
+
+- [x] B-1: `.github/workflows/test.yml` を追加する。MySQL 8.0 サービスコンテナ、`TZ: UTC`、`DATABASE_URL`、`DISABLE_SPRING=1` を含める（変更2）
+- [x] B-2: ユニットA・B-1の変更をブランチに反映してリモートに push し、GitHub Actions 上で `test` ワークフローが成功することを確認する。失敗した場合は原因（MySQL接続、TZ、アセットパイプラインなど）を切り分けてから次に進む
+
+### ユニットC: `chart_columns` の追加とビュー6箇所の置き換え、統合テスト（並列不可: 依存 = ユニットB。C-2〜C-5 は互いに並列可）
+
+CI が最小構成で緑になったことを確認してから着手する。C-1（ヘルパー本体）だけ先に必要。C-2〜C-5 は別ファイルで互いに依存しないため、subagent へ分けて同時に進めてよい。
+
+- [x] C-1: `app/helpers/stats_helper.rb` に `chart_columns(collection, top: 3)` を追加する（変更4）
+- [x] C-2: `test/helpers/stats_helper_test.rb` を追加し、0/1/2/3/4件・top変更・非破壊性をテストする（変更4）
+- [x] C-3: `app/views/stats/_recent_bounced.html.erb` の2箇所（`count_by_destination`・`count_by_reason`）を `chart_columns` 呼び出しに置き換える（変更5）
+- [x] C-4: `app/views/stats/_unique_recipient_bounced.html.erb` の3箇所（`uniq_count_by_destination`・`uniq_count_by_reason`・`uniq_count_by_sender`）を置き換える（変更5）
+- [x] C-5: `app/views/stats/_bounced_by_type.html.erb` の1箇所（Array入力）を置き換える（変更5）
+- [x] C-6: `test/controllers/stats_controller_test.rb` を追加し、期間フィルタの反映・期間ラベル表示・空期間表示をテストする（変更7）
+- [x] C-7: 変更をブランチに反映して push し、GitHub Actions 上で `test` ワークフローが緑のままであることを確認する

--- a/.claude/docs/reports/2026-08-11-test-harness-and-etc-slice-fix-result.md
+++ b/.claude/docs/reports/2026-08-11-test-harness-and-etc-slice-fix-result.md
@@ -1,0 +1,89 @@
+# 検証結果レポート: テスト基盤の整備と etc 二重計上の修正
+
+実施日: 2026-08-16
+対象: `heads/test_harness_and_etc_slice_fix`（PR #42）のユニットA・B・Cを実装し、GitHub Actions で検証
+関連計画: [.claude/docs/plans/2026-08-11-test-harness-and-etc-slice-fix-plan.md](../plans/2026-08-11-test-harness-and-etc-slice-fix-plan.md)
+関連調査: [.claude/docs/research/2026-08-11-test-harness-and-etc-slice-fix-research.md](../research/2026-08-11-test-harness-and-etc-slice-fix-research.md)
+
+## サマリ
+
+| 項目 | 結果 |
+| --- | --- |
+| 合否 | 合格。全ユニット完了、CI 2回とも成功 |
+| ユニットA・B（test基盤） | CI 1回目: 5 runs, 9 assertions, 0 failures |
+| ユニットC（etc修正） | CI 2回目: 13 runs, 29 assertions, 0 failures |
+| レビュー体制 | Cursor Agent（CLI・Herdrスペース両方）で全ユニットを収束確認 |
+| 主要な発見 | fixtures の日時が CI ランナーの `TZ` に依存して意味が変わる問題を Plan フェーズで発見・対策済み。CI実行で対策の有効性を実証 |
+
+## 検証内容
+
+### 実装したユニット
+
+ユニットA（`config/environments/test.rb` の `show_exceptions` 修正、`test/fixtures/bounce_mails.yml`、`test/models/bounce_mail_test.rb`、`test/controllers/status_controller_test.rb` の修正）とユニットB（`.github/workflows/test.yml`）は個別にローカル検証・Cursor Agentレビューを経てコミット (`6d9b0a0`, `3e2f0c9`)。ユニットC（`app/helpers/stats_helper.rb` の `chart_columns`、6箇所のビュー置き換え、`test/helpers/stats_helper_test.rb`、`test/controllers/stats_controller_test.rb`）も同様にコミット (`0280d29`)。
+
+### レビュー体制
+
+このセッションでは2種類の Cursor Agent を使い分けた。ユニットA以前（spec/research/plan フェーズ）は `cursor-agent --print --mode ask` の CLI 単発呼び出し。ユニットA・B・C の実装レビューは、herdrスペース内で稼働中の対話型 Cursor Agent（`herdr agent prompt` / `herdr agent wait` 経由）に切り替えた。後者は実際に `gh run view --log` で既存 `bundler-audit` の実行ログを確認する、`chart_columns` を実際に `mise exec -- ruby` でシミュレーション実行する、独自の to-do リストを立てて観点ごとに検証するなど、より踏み込んだ検証を行った。全3ユニットで「収束、承認してよい」の判定を得た。
+
+### 1回目のCI実行（PR #42、ユニットA・Bのみ）
+
+```
+Run options: --seed 58677
+# Running:
+.....
+Finished in 0.155635s, 32.1264 runs/s, 57.8275 assertions/s.
+5 runs, 9 assertions, 0 failures, 0 errors, 0 skips
+```
+
+`test` ジョブは45秒で完走。以下3点が Plan フェーズでの一次資料（activerecordソース読解）に基づく予測どおりであることが実行結果で裏付けられた。
+
+- `db:schema:load` だけで `maintain_test_schema!` の `PendingMigrationError` が発生しない
+- `DATABASE_URL=mysql2://root@127.0.0.1:3306/sisito_test` により `host: localhost` のソケット優先解決問題を回避できた
+- `TZ: UTC` 設定下で `within_period` の境界条件テスト4件が全て成功し、fixtures の日時が意図どおり格納された
+
+### 2回目のCI実行（PR #42、ユニットC込み）
+
+```
+Run options: --seed 4044
+# Running:
+...
+Finished in 0.959987s, 13.5419 runs/s, 30.2087 assertions/s.
+13 runs, 29 assertions, 0 failures, 0 errors, 0 skips
+```
+
+`stats#index` の統合テストがレイアウト経由でアセットパイプライン（Sprockets + dartsass-sprockets）を要求する点を plan.md で「初回赤くなりうる箇所」として挙げていたが、実際には `Sass @import rules are deprecated`（既知の非ブロッキング警告）が出るのみで問題なく完走した。`bundler-audit` ワークフローも引き続き成功。
+
+### ローカルでの事前検証（CI実行前）
+
+MySQL が無いため `bin/rails test` そのものは実行できず、以下で代替した。
+
+- `mise exec -- ruby -c` による全新規・変更 Ruby ファイルの構文チェック
+- 独自のERB構文チェッカー（`javascript_tag do` ブロックを一時的に `<%` に変換してErubiでコンパイルし `RubyVM::InstructionSequence.compile` で検証、`<% end %>` を1つ削った版で確実に検出することも確認）による3ビューファイルの検証
+- `TZ=UTC mise exec -- ruby` で fixtures YAML を実際にパースし、4レコードの `timestamp` が意図どおり1秒のずれもなく格納されることを確認
+- `chart_columns` のロジックを素のRubyでシミュレーションし、#36検証時に実際にPiで観測した境界データ（`bounced_by_mailboxfull` 3件）で `etc: 0` が混入しないこと、10件超のデータで合計が実件数と一致することを確認
+
+## 結果
+
+期待どおりだった点は、Plan フェーズで見つけた3つの技術的リスク（`maintain_test_schema!`、`DATABASE_URL`、`TZ`依存）が、いずれもCI実行で実証されたことである。特に `TZ` の問題はローカルの推測だけでは気づけず、Plan フェーズで別プロセスによる実測（`TZ=UTC`/`Asia/Tokyo`/`America/Los_Angeles`）まで行って初めて発見できたもので、対策（`TZ: UTC` の明示）が正しく効いたことを境界条件テスト4件の成功で確認できた。
+
+差分は無し。2回とも一発で成功しており、CIが初めて赤くなる可能性を懸念していた箇所（DB接続、アセットパイプライン）はいずれも問題にならなかった。
+
+## 副次的発見
+
+Rails fixtures には `DEFAULTS`（大文字）という予約キー名があり、`ActiveRecord::FixtureSet` がこれを無条件に無視することを Plan フェーズで発見した。当初は「実在するレコード名をYAMLアンカーにする」という代替策を採る予定だったが、こちらの方が Rails 標準の書き方であるため採用した。今後 sisito で fixtures を追加するときは、この `DEFAULTS: &DEFAULTS` パターンを踏襲するとよい。
+
+Herdrスペース内の対話型 Cursor Agent（`w9:p2`）は、以前 PR #35（CVE対応）のレビューにも使われた実績があり、コンテキストを保持したまま複数ユニットのレビューを連続してこなせた。CLI単発呼び出しより検証が踏み込んでいた（実際のCI実行ログの確認、コードの実行シミュレーションなど）。
+
+## 別Issue候補リスト
+
+無し。今回の変更で新たに見つかった、切り出すべき独立した課題はない。
+
+## 残課題・次のアクション
+
+- PR #42 は現在ドラフト状態。全ユニット完了・CI成功を確認したため、レビュー依頼可能な状態にする（`gh pr ready`）かどうかはユーザーの判断
+- マージ後、Issue #38・#39 のクローズを確認する
+- Pi へのデプロイは本タスクのスコープ外（テスト基盤とチャート表示ロジックの変更であり、#36のような実データ検証は不要と判断。ただしマージ後、Pi上での見た目の変化（チャート個別表示が10件→3件に減る）は運用者への周知が必要）
+
+## 結論
+
+3ユニットすべてが実装・検証・承認のゲートを通過し、GitHub Actions上で2回とも一発成功した。テスト基盤が初めて機能する状態になり（stale だった唯一のテストが直り、CIで実際に走るようになった）、その基盤の上で `etc` 二重計上バグを回帰テスト付きで修正できた。Plan フェーズで発見した `TZ` 依存というfixtures設計上の罠は、対策なしに進んでいれば CI が原因不明に間欠的に失敗する（あるいはCIランナーの既定TZがたまたまUTCである限り気づかれない）類の問題であり、実装前に発見・検証できたことがこのセッションの主要な収穫である。

--- a/.claude/docs/research/2026-08-11-test-harness-and-etc-slice-fix-research.md
+++ b/.claude/docs/research/2026-08-11-test-harness-and-etc-slice-fix-research.md
@@ -1,0 +1,254 @@
+# テスト基盤の整備と etc 二重計上の修正 調査レポート
+
+日時: 2026-08-11
+
+設計仕様: [.claude/docs/specs/2026-08-11-test-harness-and-etc-slice-fix-spec.md](../specs/2026-08-11-test-harness-and-etc-slice-fix-spec.md)
+
+## 対象範囲
+
+読んだファイルは以下のとおり。
+
+- `test/test_helper.rb`、`test/controllers/status_controller_test.rb`
+- `test/` 配下のディレクトリ構成（`.keep` の有無）
+- `config/environments/test.rb`、`config/database.yml`、`config/secrets.yml`
+- `config/routes.rb`
+- `.github/workflows/bundler-audit.yml`、直近の実行ログ（`gh run view --log`）
+- `Gemfile`、`mise.toml`
+- `db/schema.rb`（`bounce_mails` / `whitelist_mails` の全カラム）
+- `db/migrate/20170128144003_example_data.rb`
+- `app/controllers/stats_controller.rb`、`app/controllers/status_controller.rb`、`app/controllers/application_controller.rb`
+- `app/models/bounce_mail.rb`
+- `app/helpers/stats_helper.rb`
+- `app/views/stats/_recent_bounced.html.erb`、`_unique_recipient_bounced.html.erb`、`_bounced_by_type.html.erb`
+- `app/views/layouts/application.html.erb`
+- actionpack 7.2.3.2 の `lib/action_dispatch/middleware/exception_wrapper.rb`（Pi 上の `vendor/bundle` で実物を確認）
+- activerecord 7.2.3.2 の `lib/active_record/migration.rb`、`lib/active_record/tasks/database_tasks.rb`、`lib/active_record/schema.rb`、`lib/active_record/connection_adapters/abstract/schema_statements.rb`、`lib/active_record/railties/databases.rake`（Pi 上の `vendor/bundle` で実物を確認。`Gemfile.lock` と一致するため CI に入る gem と同一）
+- activerecord 7.2.3.2 の `lib/active_record/fixtures.rb`、`lib/active_record/fixture_set/file.rb`、`lib/active_record/fixture_set/table_row.rb`、`lib/active_record/connection_adapters/abstract/database_statements.rb`、`lib/active_record/connection_adapters/abstract/quoting.rb`、`lib/active_record/connection_adapters/mysql/quoting.rb`（fixtures の読み込み・型変換・SQL生成の経路）
+- activemodel 7.2.3.2 の `lib/active_model/type/date_time.rb`
+- `ActiveSupport::ConfigurationFile`（fixtures YAML の読み込み方式）
+- Ruby の `Array#slice` / `Array#to_a` / `Array#drop` の挙動、YAML の日時文字列パースと `Time#getlocal` の挙動（`mise exec -- ruby -e` および `TZ=X mise exec -- ruby` によるプロセス分離実測）
+
+## 既存類似実装
+
+類似度は高い。#36（PR #37）で `BounceMail.within_period` scope と `StatsHelper#stats_period_label` を追加した実績があり、今回の `chart_columns` ヘルパーも同じ「6箇所の重複を1箇所に集約する」パターンの繰り返しになる。採用方針は #36 のパターンを踏襲する（`StatsHelper` にメソッドを足し、ビュー側は呼び出すだけにする）。
+
+CI ワークフローの類似実装は `.github/workflows/bundler-audit.yml` のみで、ジョブ構成（`actions/checkout@v4` → `ruby/setup-ruby@v1` with `bundler-cache: true`）をそのまま流用できる。ただしこのワークフローはデータベースを使わないため、MySQL サービスコンテナの部分は新規に書く必要がある。
+
+## 既存パターンと規約
+
+### テストの命名・配置規約
+
+`test/` は Rails 標準の Minitest 構成で、`test_helper.rb` が `ENV['RAILS_ENV'] ||= 'test'` → `config/environment` → `rails/test_help` の順に読み込み、`ActiveSupport::TestCase` に `fixtures :all` を仕込んでいる。既存の唯一の実テストファイルはコントローラ配下に `ActionDispatch::IntegrationTest` を継承する形で書かれており（`test/controllers/status_controller_test.rb`）、`get monitor_index_url` のように名前付きルートヘルパーを使う。今回追加するテストもこの規約に従う。
+
+`test/models/.keep`、`test/helpers/.keep`、`test/fixtures/.keep`（`files/.keep` も含む）が既に存在し、対応するディレクトリは作成済みだが中身が無い状態。`test/models/bounce_mail_test.rb`、`test/helpers/stats_helper_test.rb`、`test/fixtures/bounce_mails.yml` はこの空ディレクトリに新規追加する形になる。
+
+### CI ワークフローの規約
+
+`bundler-audit.yml` は `on: push (master) / pull_request / schedule (weekly)` の3トリガー構成で、`ruby/setup-ruby@v1` に `ruby-version` を明示していない。直近の実行ログ（`gh run view --log`）で `ruby-version: default` → `Using 3.4.9 as input from file mise.toml` → `ruby 3.4.9` のインストールが確認でき、リポジトリに `.ruby-version` が無くても `mise.toml` の `ruby = "3.4.9"` を自動検出することが実証済みである。新設する `test.yml` も同じ `ruby/setup-ruby@v1` の使い方で Ruby バージョンの整合を取れる。
+
+### ヘルパーへの集約規約
+
+#36 で確立した規約は「重複する定型ロジックを `StatsHelper` の1メソッドに集約し、呼び出し元は薄くする」というもの。`stats_period_label(from, to)` が前例になる。今回の `chart_columns(collection, top: 3)` もこの規約を踏襲する。
+
+## 重要な発見
+
+### `config.action_dispatch.show_exceptions = false` は Rails 7.2 で意図と逆に働く
+
+`config/environments/test.rb` の該当行は Rails 標準テンプレートの古い書き方（boolean）のまま残っている。actionpack 7.2.3.2 の `ExceptionWrapper#show?`（`lib/action_dispatch/middleware/exception_wrapper.rb`）は次の case 式で判定する。
+
+```ruby
+def show?(request)
+  config = request.get_header("action_dispatch.show_exceptions")
+  case config
+  when :none
+    false
+  when :rescuable
+    rescue_response?
+  else
+    true
+  end
+end
+```
+
+`false` は `:none` にも `:rescuable` にも一致しないため `else` に落ち、`true`（例外ページを表示する＝例外を re-raise しない）と解釈される。したがって現状のまま統合テストを書くと、コントローラ内で例外が起きても Minitest には伝播せず 500 のレンダリングになり、失敗理由が読み取りにくくなる。`:none` に変更することで、テスト内の例外は素通しで re-raise され、通常の Ruby の例外としてテスト失敗の原因になる。
+
+### `db:migrate` は非決定的なデータを投入する
+
+`db/migrate/20170128144003_example_data.rb` は `(1..100).flat_map { ... }` で `BounceMail.create!` を700回呼び、各レコードの `timestamp` / `created_at` / `updated_at` に `Date.today - rand(14).days` を使う。実行するたびに異なる日付・組み合わせのデータが入るため、境界条件を固定日付で検証するテストとは原理的に両立しない。加えて `WhitelistMail.create!` も3行、`Date.today` を基準にした日付で投入する。
+
+`db/schema.rb` にはデータが含まれないため、CI では `db:schema:load` に固定し、`db:migrate` の実行（＝このマイグレーションを含む全履歴の適用）を避ける必要がある。
+
+### `db:schema:load` だけで `maintain_test_schema!` は素通りする
+
+Rails は `test_helper.rb` の `require 'rails/test_help'` 経由で `ActiveRecord::Migration.maintain_test_schema!` を自動的に呼ぶ。これが「pending migrations」エラーでテスト実行を止める可能性があるかどうかを、Pi 上の実物の gem（`vendor/bundle/ruby/3.4.0/gems/activerecord-7.2.3.2`。`Gemfile.lock` と一致するため CI で入る gem と同一）のソースを読んで確認した。
+
+`maintain_test_schema!` は `load_schema_if_pending!` を呼び、その中身は次の2段構えになっている（`lib/active_record/migration.rb:716-728`）。
+
+```ruby
+def load_schema_if_pending!
+  if any_schema_needs_update?
+    system("bin/rails db:test:prepare")
+  end
+  check_pending_migrations
+end
+```
+
+`any_schema_needs_update?` は `schema_up_to_date?`（`lib/active_record/tasks/database_tasks.rb:389-402`）を呼び、`ar_internal_metadata` テーブルの `schema_sha1` と現在の `db/schema.rb` の sha1 を比較する。`db:schema:load` タスク（`schema:load` → `DatabaseTasks.load_schema_current` → `DatabaseTasks.load_schema`、`lib/active_record/railties/databases.rake:502` と `lib/active_record/tasks/database_tasks.rb:368-387`）は、schema.rb を読み込んだ直後に `internal_metadata.create_table_and_set_flags(db_config.env_name, schema_sha1(file))` で正しい sha1 を書き込む。したがって CI で標準の `bin/rails db:schema:load` を使う限り `schema_up_to_date?` は `true` を返し、`db:test:prepare` の再実行（システムコール）は起きない。
+
+`check_pending_migrations` は無条件に呼ばれ、`db/migrate/*.rb` のバージョンが `schema_migrations` テーブルに記録済みかを見る。ここで鍵になるのが `ActiveRecord::Schema.define`（`lib/active_record/schema.rb:54-62`）が呼ぶ `connection.assume_migrated_upto_version(info[:version])` の実装（`lib/active_record/connection_adapters/abstract/schema_statements.rb:1340-1359`）である。
+
+```ruby
+def assume_migrated_upto_version(version)
+  ...
+  versions = migration_context.migrations.map(&:version)
+  ...
+  inserting = (versions - migrated).select { |v| v < version }
+  ...
+  execute insert_versions_sql(inserting)
+end
+```
+
+`migration_context.migrations` は `db/migrate/` に存在する全マイグレーションファイルを（実行するかどうかに関わらず）走査してバージョン番号を集める。`schema.rb` の `version:`（`2026_04_25_000001`）より小さい全バージョンが、実際にはマイグレーションの `change`/`up` を1行も実行しないまま `schema_migrations` に挿入される。つまり `20170128144003_example_data.rb` のバージョンも「migrated 済み」としてマークされる一方、その中身（`Date.today - rand(14).days` での700行投入）は一切実行されない。
+
+以上から、CI で `db:create` → `db:schema:load` の順に実行してから `rails test` を走らせれば、`maintain_test_schema!` は `schema_sha1` の一致で早期リターンし、`pending_migrations` も空になるため、`PendingMigrationError` は発生しない。`ActiveRecord.maintain_test_schema = false` のような回避策は不要で、標準のタスク呼び出しだけで足りる。
+
+### fixtures の必須カラムと落とし穴
+
+`bounce_mails` は `id` を除き 24 カラムあり、`digest`（`default: ""`）以外はすべて `null: false` かつデフォルト値を持たない。fixtures で共通デフォルトを素朴な YAML アンカー（トップレベルキー名を自分で決めて `&anchor` にする）で作ると、そのキー自体が1件の `bounce_mails` フィクスチャとして解釈され、集計・件数のテストに余分な1行が混入しかねない。ただし Rails の fixtures にはこの状況にちょうど対応する組み込み機能があり、`lib/active_record/fixtures.rb:435-455` のコメントに明記されている。トップレベルキーを大文字の `DEFAULTS` にすると、`FixtureSet#ignored_fixtures`（同ファイル）が `@ignored_fixtures << "DEFAULTS"` を無条件に行い、このキーは実データとして挿入されない。「実在するレコード名をアンカーにする」よりもこちらが Rails 標準の書き方であり、採用する。
+
+`whitelist_mails` は `digest` が `null: false` かつデフォルト値なしで、`recipient` / `senderdomain` はデフォルト `""` を持つ。今回追加するテスト（`within_period` の境界条件、`chart_columns` の等価性、`status` のスモーク、`stats#index` の統合テスト）はいずれも `whitelist_mails` を参照するコードパスに触れないため、このテーブルの fixtures は不要と判断できる。
+
+### fixtures の日時は CI ランナーの TZ に依存して意味が変わる
+
+`bounce_mails.timestamp` のような datetime 型カラムに fixtures でオフセット無しの日時文字列（例: `2026-08-01 00:00:00`）を書くと、実際に DB に格納される値は fixtures を読み込むプロセスの `TZ` 環境変数に依存する。この依存は暗黙的で、CLAUDE.md が要求する「fixtures は `Date.today` に依存せず決定的であること」という前提を静かに破りうる。以下の経路で確認した。
+
+fixtures の YAML は `ActiveSupport::ConfigurationFile#parse` が ERB 展開後に `YAML.unsafe_load` でパースする（Psych の素の日時パース）。オフセット無しの日時文字列は Psych の暗黙型解決により UTC の瞬間として解釈されるが、返される `Time` オブジェクトはプロセスのローカルタイムゾーンに変換済みの表現になる。これは `mise exec -- ruby` でプロセスを分けて実測して確認した。
+
+```
+$ TZ=UTC mise exec -- ruby -ryaml -e 'p YAML.unsafe_load("t: 2026-08-01 00:00:00")["t"]'
+2026-08-01 00:00:00 +0000
+$ TZ=Asia/Tokyo mise exec -- ruby -ryaml -e 'p YAML.unsafe_load("t: 2026-08-01 00:00:00")["t"]'
+2026-08-01 09:00:00 +0900
+$ TZ=America/Los_Angeles mise exec -- ruby -ryaml -e 'p YAML.unsafe_load("t: 2026-08-01 00:00:00")["t"]'
+2026-07-31 17:00:00 -0700
+```
+
+同じ YAML 文字列が、パースするプロセスの `TZ` によって異なる時刻（日付をまたぐ場合すらある）の `Time` オブジェクトになる。
+
+fixtures の挿入 SQL は `build_fixture_sql`(`lib/active_record/connection_adapters/abstract/database_statements.rb:558-577`)が `type.serialize(fixture[name])` でカラム型にキャストし、`datetime` 型（`ActiveModel::Type::DateTime#cast_value`、`lib/active_model/type/date_time.rb`）は値がすでに `Time` オブジェクトなら文字列パースをスキップしてそのまま使う。最終的に Arel が SQL リテラルへ変換する際、`Time` 値は `quoted_date`（`lib/active_record/connection_adapters/abstract/quoting.rb:184-198`）を経由し、`default_timezone == :local` のとき `value.getlocal` が呼ばれる。`config/application.rb:22` の `config.active_record.default_timezone = :local` によりこの分岐が使われる。
+
+つまり fixtures の日時文字列は「Psych がプロセスの TZ で解釈した時刻」が「その TZ のまま」DB に書き込まれる。GitHub Actions の `ubuntu-latest` ランナーは既定で `Etc/UTC` だが、これは実装が依存してよい明文化された契約ではなく、ランナーイメージの既定値である。fixtures にオフセット無しの日時文字列を書く設計は、CI の実行環境の TZ に暗黙に依存することになり、日付境界を1秒単位で検証する `within_period` の境界条件テストにとってはこの依存が致命的になりうる（`TZ` が UTC からずれると、`boundary_start`/`boundary_end` の実際の格納値が日付をまたいでずれ、意図した境界と異なる境界を検証してしまう）。
+
+対策として、CI ジョブの `env` に `TZ: UTC` を明示的に設定し、fixtures の日時文字列は UTC 前提の値として書く。これによりランナーの既定値に依存せず、意図と保存値が常に一致することを保証する。
+
+### `StatusController#index` は現在時刻基準の集計窓を持つ
+
+```ruby
+interval = (Rails.application.config.sisito.dig(:status, :interval) || 60).to_i
+start_time = Time.now - interval
+status = cache_if_production(:status, expires_in: interval - 5) do
+  bounce_mails = BounceMail.where('timestamp >= ?', start_time - interval).to_a
+  ...
+```
+
+集計対象は「実行時刻から `2 × interval`（既定 120 秒）以内」に限られる。fixtures に入れる固定の過去日時（境界条件検証用の日付）はこの窓の外側になるため、`bounce_mails` の件数を fixtures 経由で断言するテストは書けない。ルーティングの是正（`monitor_index_url` → `status_url`）と HTTP 200 のスモーク確認に留めるのが妥当で、JSON の中身を検証するなら `travel_to` で時刻を固定するか、実行都度計算した時刻を使う必要があり、今回のスコープには含めない。
+
+### `chart_columns` が担うべき正確な契約
+
+6箇所の現行コードはすべて次の形を持つ（`_bounced_by_type` のみ入力がソート済み Array、他5箇所は Hash）。
+
+```ruby
+collection.to_a.slice(0, 10)
+  .push(['etc', <values>.slice(3..-1).try(:sum)])
+  .select {|_, v| v.present? }
+```
+
+個別表示 10 件・`etc` 集計対象4件目以降という不一致が二重計上の原因（research.md 2026-08-10 版で既出）。新設する `chart_columns(collection, top: 3)` はこの `top` を単一の情報源にし、個別表示・`etc` 集計とも同じ `top` を使う。
+
+`etc` を出すかどうかの判定には、既存コードの `try(:sum)` → `present?` という経路を単純に踏襲してはいけない。Ruby の `Array#slice(range)` は、開始位置が配列長と等しいとき `[]` を返し、配列長を超えるとき `nil` を返す（`mise exec -- ruby` での実測で確認）。
+
+```
+[1,2,3].slice(3..-1)   => []    (配列長3、開始位置3 = 長さと等しい)
+[1,2].slice(3..-1)     => nil   (配列長2、開始位置3 > 長さ)
+[1,2,3,4].slice(3..-1) => [4]
+```
+
+現行コードの `values.slice(3..-1).try(:sum)` は、対象が0〜2件のときは `nil.try(:sum)` で `nil` になり `present?` で弾かれ `etc` が出ない。しかし対象がちょうど3件のときは `[].try(:sum)` が `0` を返し、`0.present?` は `true` であるため、**現行コードは既にこの境界（ちょうど3件）で `etc: 0` を出している**。これは推測ではなく、本調査中に Pi 上で再現して確認した事実である。まず `bounce_mails` から destination がちょうど3種類になる reason・日付の組を SQL で特定した。
+
+```sql
+SELECT reason, DATE(timestamp) AS d, COUNT(DISTINCT destination) AS n
+FROM bounce_mails
+WHERE timestamp >= "2026-08-01" AND timestamp < "2026-08-16"
+GROUP BY reason, DATE(timestamp)
+HAVING n = 3
+ORDER BY d DESC LIMIT 5;
+-- => mailboxfull 2026-08-09 3
+```
+
+`reason=mailboxfull` かつ `2026-08-09` の destination 内訳を確認すると `icloud.com: 6, gmail.com: 4, softbank.ne.jp: 2` の3件だった。この日付をそのまま `from`/`to` に指定して Pi 上の稼働中インスタンスにリクエストを送った。
+
+```
+curl 'http://localhost:1080/?from=2026-08-09&to=2026-08-09'
+```
+
+返ってきた HTML から `#bounced_by_mailboxfull` の `c3.generate` ブロックを抜き出すと次のとおりだった。
+
+```
+columns: [["icloud.com", 6], ["gmail.com", 4], ["softbank.ne.jp", 2], ["etc", 0]]
+```
+
+3件の個別スライスに加えて `["etc", 0]` が実際に出力されている。境界（ちょうど3件）で `etc: 0` が混入するという Ruby の意味論上の予測が、稼働中のコードで確かに発生することを確認した。
+
+したがって `chart_columns` の実装は、`slice(top..-1)`（要素数不足時に `nil` を返し得る）ではなく `drop(top)`（要素数によらず必ず `Array` を返し、0件残りなら `[]`）を使い、判定は `present?`（`0` を通してしまう）ではなく `.empty?` で行う必要がある。`slice` のまま `.empty?` に変えるだけだと、0〜2件残りのケースで `nil.empty?` の `NoMethodError` になるため、切り出し方法と判定方法は対で変える。
+
+もう一点、`chart_columns` は Hash と `[key, count]` の pair 配列の両方を受け取る設計にするため、内部では常に pair 配列として扱うことになる。このとき残り部分の合計は `pairs.drop(top).sum` とは書けない。`sum` はブロック無しだと各要素を `+` で足そうとし、要素が `[key, count]` という2要素配列なので `TypeError: Array can't be coerced into Integer` になる（`mise exec -- ruby` で実測済み）。現行コードが `hash.values.slice(...)` や `count_by_destination.map(&:last).slice(...)` のように事前に count だけを取り出しているのはこのためで、`chart_columns` では `pairs.drop(top).sum {|_, v| v }` のように明示的に count を取り出すブロックが要る。この点は `ruby -c` の構文チェックでは検出できず、Plan フェーズのコードスニペットと単体テスト（0/1/2/3/4件のケース）で担保する。
+
+### `top: 3` は正しさではなく見やすさの選択
+
+`etc` の二重計上を直すこと自体は、個別表示件数を何件にしても実現できる。個別表示を `first(N)`、`etc` を `drop(N).sum` にすれば、N が10でも3でも合計は元のコレクションの合計と必ず一致する。つまり「個別表示を3件に揃える」（spec の要件ごとの実装方針、AskUserQuestion で N=3 を選択）は二重計上を直すために必須の変更ではなく、チャートの凡例を短くして見やすくするための独立した選択である。この経緯は spec / Issue #38 に記録されているが、次にこのコードを読む人が「バグを直すには表示件数を減らすしかなかった」と誤解しないよう、ここに明記しておく。
+
+### `Array#to_a` は Array に対して self を返す
+
+```ruby
+a = [1,2,3]
+a.to_a.equal?(a)  # => true
+```
+
+`_bounced_by_type.html.erb` から渡される `count_by_destination`（`sort_by(&:last).reverse` 済みの Array）に対して `chart_columns` 内で `.to_a` を呼んでも、新しいオブジェクトは作られない。ここで `push` のような破壊的メソッドを直接使うと呼び出し元の変数まで書き換わる。ただし `Array#first(n)` と `Array#drop(n)` はどちらも非破壊的で常に新しい配列を返すため、`columns = pairs.first(top)` のように非破壊メソッドで新しい配列を作ってから、その新しい配列に対して `<<` で `etc` 行を追加する設計にすれば、`pairs`（＝呼び出し元の Array がそのまま渡ってきている可能性がある変数）自体は変更されない。旧コードも `.to_a.slice(0, 10)` の `slice` が新しい配列を返すため実害は無かったが、ヘルパーとして切り出す際に `first`/`drop` を経由する設計を維持する必要がある。
+
+### `stats#index` の統合テストにおける日付の非決定性
+
+```ruby
+@recent_days_to = params[:to].present? ? params[:to].to_date : Date.today
+default_recent_days = Rails.application.config.sisito.fetch(:default_recent_days, 14)
+@recent_days_from = params[:from].present? ? params[:from].to_date : @recent_days_to - default_recent_days
+```
+
+`params[:from]`/`[:to]` を指定しないリクエストは `Date.today` を基準に既定期間（14日）を計算する。fixtures の日付を固定しても、テストが `params` を渡さずにデフォルト期間に頼ると、実行日によって fixtures の日付が対象期間の内外を行き来し、テストが非決定的になる。統合テストは必ず `get root_path, params: { from: ..., to: ... }` のように固定の `from`/`to` を明示し、fixtures の日付と一致させる。
+
+「8チャートが描画される」という表現も正確ではない。`StatsController#index` が持つ集計ブロックは8つ（`@count_by_date` 他3つ、`@uniq_count_by_*` 3つ、`@bounced_by_type` 1つ）だが、`_bounced_by_type.html.erb` は `@bounced_by_type` の reason 数だけ `c3.generate` ブロックを生成する（`each_slice` ループ）。したがって「描画されるチャートの絶対数」ではなく「8つの集計ブロックそれぞれが期間フィルタを反映していること」を確認する、という言い方が正確である。
+
+### レイアウトはアセットパイプラインを経由する
+
+`app/views/layouts/application.html.erb` は `stylesheet_link_tag 'application'` と `javascript_include_tag 'application'` を持つ。`stats#index` はこのレイアウトでレンダリングされるため、統合テストで `get root_path` を叩くとアセットパイプライン（Sprockets + dartsass-sprockets、Terser）がテスト環境で解決できる必要がある。CI 上で `bundle install` 後にこの経路が動くかどうかは、テストを実際に走らせて確認する必要がある事項であり、Plan フェーズで CI ワークフローの手順に組み込む。
+
+## 注意点・リスク
+
+`config/environments/test.rb` の変更は `show_exceptions` の1行に留める。この環境ファイルには他にも `config.cache_classes = true`、`config.eager_load = false` など標準的な設定があるが、今回のスコープはテストを通すことであり、Rails 7.2 向けの網羅的なモダナイズは行わない。
+
+`etc` の修正はチャートの表示数値を変える。個別表示件数を10件から3件に減らすため、これまで4〜10位に表示されていた項目が個別表示から消え `etc` に吸収される。数値の正しさは改善するが、画面の見た目（表示される個別ラベルの数）が変わる点は Issue #38 に記載済みで、リリース時に改めて周知する。
+
+CI にジョブを追加すると、既存の `bundler-audit`（約25秒）に加えて MySQL サービスコンテナの起動・`bundle install`・`db:schema:load`・テスト実行が加わり、PR ごとの待ち時間が増える。基盤整備の初回はこの増分を許容する前提で進める。
+
+## バグ調査の場合
+
+該当箇所は次の6箇所。個別表示・`etc` 集計とも `top: 3` に統一する。
+
+- `app/views/stats/_recent_bounced.html.erb:72-77`（`count_by_destination`）
+- `app/views/stats/_recent_bounced.html.erb:90-95`（`count_by_reason`）
+- `app/views/stats/_unique_recipient_bounced.html.erb:30-35`（`uniq_count_by_destination`）
+- `app/views/stats/_unique_recipient_bounced.html.erb:50-55`（`uniq_count_by_reason`）
+- `app/views/stats/_unique_recipient_bounced.html.erb:67-72`（`uniq_count_by_sender`）
+- `app/views/stats/_bounced_by_type.html.erb:29-34`（reason 別、入力が Hash ではなく Array）
+
+再現手順は、任意の期間で destination（または reason／sender）の種類数がちょうど3件になるような絞り込みを行い、レスポンス中の該当 `columns` に `["etc", 0]` が含まれることを確認する。#36 の Pi 検証時に `bounced_by_mailboxfull`（3件）で実際に観測済み。4件以上のケースでは `etc` の値が4件目以降の合計になり、個別表示の4〜10位と二重計上される（例: `bounced_by_userunknown` で10件中4〜10位の合計が `etc` にも含まれ、チャート合計が実件数を超える）。

--- a/.claude/docs/specs/2026-08-11-test-harness-and-etc-slice-fix-spec.md
+++ b/.claude/docs/specs/2026-08-11-test-harness-and-etc-slice-fix-spec.md
@@ -1,0 +1,123 @@
+# テスト基盤の整備と etc 二重計上の修正 設計仕様
+
+日時: 2026-08-11
+深度: standard
+対象 Issue: [#39](https://github.com/revsystem/sisito/issues/39)（テスト基盤）、[#38](https://github.com/revsystem/sisito/issues/38)（etc 二重計上）
+
+## 目的・コンセプト
+
+自動テストが一切機能していない状態を解消し、その基盤の上で `etc` 二重計上バグを修正する。
+
+#36 の実装では、日付範囲フィルタという明確なロジック変更に対して自動テストを 1 本も追加できず、検証は Pi 上での実地確認と直接 SQL の突き合わせに全面依存した。手作業のコストが高いだけでなく、`BounceMail.within_period` の境界条件（`to` 当日を含む）のような一度確認した性質が、次の変更で壊れても誰も気づけない。
+
+#38 はチャートの表示数値が変わる修正であり、まさに回帰テストが欲しい種類の変更である。したがって #39 を先に片付け、#38 はその基盤の上でテストと同時に実装する。
+
+## 想定利用者と利用シーン
+
+利用者はリポジトリ所有者本人。ローカル（WSL2）は編集専用で MySQL が無く gem も入れない方針のため、テストを日常的に走らせる場所は GitHub Actions になる。PR を出したときに自動で走り、壊れていれば PR 上で分かる、という使い方を想定する。
+
+最重要の制約として、Raspberry Pi は唯一の実運用ホストであり、そこにテスト用データベースを置かない。Rails のテストは対象データベースを破棄・再生成するため、`sisito_development` と同居させる価値よりリスクが大きい。
+
+## スコープ
+
+含めること。GitHub Actions へのテストジョブ追加（MySQL 8.0 サービスコンテナ）、`config/environments/test.rb` の Rails 7.2 準拠への修正、stale な `status_controller_test.rb` の修正、`bounce_mails` の fixtures 作成、`BounceMail.within_period` の境界条件テスト、`etc` 二重計上の修正（6 箇所）とそのテスト。
+
+含めないこと。網羅的なテストの追加。既存の全コントローラ・全ビューを covered にすることは目指さない。カバレッジ計測ツール（simplecov 等）の導入も行わない。`shorten_stats` や OAuth 経路のテストも今回は書かない。
+
+線引きの根拠は、基盤が無い状態から一気に網羅を目指すと、fixtures の設計だけで作業が発散するためである。「CI で走る」「意味のあるテストが数本ある」「#38 が守られる」の 3 点を満たすところまでを今回の到達点とし、以降は変更のたびに足していく。
+
+## アーキテクチャ設計
+
+テストの実行環境は GitHub Actions のみとする。ワークフローは既存の `bundler-audit.yml` と別ファイル（`.github/workflows/test.yml`）に分ける。目的が違い、トリガも異なる（bundler-audit は weekly cron を持つがテストには不要）ためである。
+
+データベースは `services:` の MySQL 8.0 コンテナを使い、`config/database.yml` の test ブロックが指す `sisito_test` に `db:schema:load` でスキーマを流す。migration を順に当てるのではなく `schema.rb` を読ませる方式にするのは、`20250705000002` が MySQL では部分インデックスにならないなど、migration 履歴に環境依存の癖があるためだけではない。より直接的な理由は `db/migrate/20170128144003_example_data.rb` の存在で、これは `Date.today - rand(14).days` で約 700 行の `bounce_mails` と 3 行の `whitelist_mails` を投入する。境界条件テストが要求する「固定の日付・件数」と非決定的な乱数データは両立しない。`db:migrate` で履歴を素直に辿るとこのマイグレーションを踏んでしまうため、CI は `db:create` の後 `db:schema:load` に固定し、migration 履歴を辿らせない。`schema.rb` にはデータが無く、CI が検証すべきはそちらになる。
+
+テストの種類はモデルテストとコントローラ（統合）テストの 2 層に留める。システムテスト（ブラウザ駆動）は導入しない。C3.js のチャートはサーバー側が生成した JS リテラルをそのまま埋め込む構造なので、`etc` の計算のようなロジックはレスポンス本文の文字列として検証できる。ヘッドレスブラウザを持ち込む必要がない。
+
+## 技術選定と根拠
+
+テストフレームワークは Rails 標準の Minitest をそのまま使う。`test/` ディレクトリと `test_helper.rb` が既にあり、RSpec への移行は本タスクの目的ではない。
+
+fixtures は Rails 標準の YAML fixtures を使う。FactoryBot は依存が増え、`bounce_mails` のように全カラムが `NOT NULL` のテーブルではデフォルト値の定義場所が変わるだけで利点が薄い。
+
+MySQL は 8.0 系をサービスコンテナで使う。Pi の本番相当環境と揃えるためで、SQLite への差し替えはしない。`sql_mode: TRADITIONAL` の挙動や `COUNT(DISTINCT ...)` の扱いが変わると、テストが通っても実環境で壊れる余地が生まれる。
+
+## データ設計
+
+スキーマ変更なし。
+
+fixtures は `bounce_mails` のみを用意する。`bounce_mails` は `id` を除く 24 カラムすべてが `NOT NULL`（`digest` のみ `default: ""` を持つ）で、共通のデフォルトを YAML の ERB か fixture の共通定義でまとめ、テストごとに意味のあるカラム（`timestamp`、`reason`、`destination`、`recipient`、`addresser`、`addresseralias`、`senderdomain`）だけを上書きする形にする。
+
+共通デフォルトを YAML アンカー（`defaults: &defaults` をトップレベルキーとして書く形）で作ると、`defaults` という名前自体が 1 件の `bounce_mails` 行として fixtures に登録されてしまう。全カラム NOT NULL のテーブルではこの行にも有効な値が要求され、境界条件テストの件数・`within_period` の集計件数に 1 行余分に乗る。実装時は ERB でハッシュを組み立てて各エントリに展開するか、既存の実レコード 1 件目をアンカーにするなど、トップレベルにダミーの fixture 行を作らない書き方にする。
+
+`whitelist_mails` の fixtures は用意しない。今回追加するテスト（`within_period` の境界条件、`etc` の合計一致、`status` のスモーク、`StatsController#index` の統合テスト）はいずれも `whitelist_mails` を参照しないためである。`whitelist_mails.digest` は `NOT NULL` かつデフォルト値が無く、用意する場合は明示的に値が要る点は今後の参考として記録しておく。
+
+fixtures の中身は、境界条件と集計ロジックを検証できる最小構成にする。日付境界の検証には「範囲の開始日 00:00:00」「終了日 23:59:59」「終了日翌日 00:00:00」の 3 点が要る。`etc` の検証には、個別表示件数 N を超える件数の destination が必要になる。`StatsController#index` の統合テストに使う fixtures の日付は固定値とし、テストのリクエストでも `params[:from]` / `params[:to]` を同じ固定値で明示的に渡す。`index` のデフォルト期間（`params` が無ければ `to = Date.today`）に乗せると、`Date.today` が動くたびに fixtures の日付が既定表示の範囲から外れ、テストが非決定的になる。
+
+## 要件ごとの実装方針
+
+`config/environments/test.rb` の `config.action_dispatch.show_exceptions = false` を `:none` に改める。actionpack 7.2.3.2 の `ExceptionWrapper#show?` は `:none` / `:rescuable` / else の case 判定であり、boolean の `false` は else に落ちて「例外を表示する」と解釈される。現状のままだと統合テストで例外が送出されず 500 が描画されるため、テストの失敗理由が分かりにくくなる。
+
+`status_controller_test.rb` はクラス名を `StatusControllerTest` に直し、`monitor_index_url` を実在する `status_url` に変える。`StatusController#index` の集計窓は `Time.now - interval` を都度計算するため、fixtures に入れた固定の過去日時は集計対象から外れる。この修正はルーティングの是正と HTTP 200 のスモーク確認に留め、JSON の中身（件数）は断言しない。中身を検証するなら `travel_to` で時刻を固定するか、集計窓に入る時刻を都度計算して fixtures を作る必要があり、これは今回のスコープ外とする。
+
+`etc` の修正は個別表示件数を 3 件に揃える。個別スライスは上位 3 件、`etc` は残り全件の合計とすることで、両者の合計が実件数と一致する。この定型は 6 箇所に重複しており、`_bounced_by_type` だけ入力が Hash ではなくソート済み Array である点を吸収する必要がある。ヘルパーへの切り出しは残決定事項とする。
+
+ヘルパーの契約として、残りが空の場合は `etc` 行を追加しないことを明記する。現行コードは `values.slice(3..-1).try(:sum)` が返す `nil` を `present?` で弾いており、対象が 3 件未満なら `etc` が出ない。ただし対象がちょうど 3 件のときは `slice(3..-1)` が `nil` ではなく空配列 `[]` を返し、`[].try(:sum)` は `0`、`0.present?` は `true` となるため、現行コードは既にこのケースで `etc: 0` を出している（#36 の Pi 検証時に実データで観測: `bounced_by_mailboxfull` が `icloud.com: 4, gmail.com: 2, softbank.ne.jp: 1` の 3 件に対し `etc: 0` を含んでいた）。したがって「残りが空なら `etc` を出さない」は新実装で初めて必要になる配慮ではなく、既存コードが `nil` 経由でしか担保できていなかった契約を、境界（ちょうど 3 件）まで含めて明示的に担保し直す修正になる。実装は `slice(top..-1)`（要素数が `top` 未満だと `nil` を返し得る）ではなく `drop(top)`（要素数によらず必ず `Array` を返す。0 件残りなら `[]`）を使い、`present?`（`0` を通す）ではなく `.empty?` で残りの有無を判定する。`slice` を残したまま `present?` を `empty?` に変えるだけでは、0〜2 件残りのケースで `nil.empty?` が `NoMethodError` になるため、切り出し方法と判定方法は必ず対で変える。
+
+もう一点、ヘルパーは受け取ったコレクションを破壊しないことも契約に含める。`Array#to_a` は自身が `Array` のとき同一オブジェクトを返すため、`_bounced_by_type` から渡されるソート済み配列に対して `to_a` を呼んでも新しい配列は作られない。その後に `push` 等の破壊的メソッドを使うと呼び出し元の配列まで変更されるため、ヘルパー内部では複製してから操作する。
+
+## 性能・品質・セキュリティ上の前提
+
+CI の実行時間が増える。MySQL コンテナの起動、`bundle install`（キャッシュあり）、`db:schema:load`、テスト実行で数分を見込む。PR ごとに走るため、テストが遅くなるとレビューの待ち時間になる。今回追加するテストは数本なので当面は問題にならない。
+
+`config/secrets.yml` に test 用の `secret_key_base` が含まれており、これは既にリポジトリに追跡されている。CI で新たに秘密情報を渡す必要はない。MySQL サービスコンテナのパスワードは `config/database.yml` の test ブロックが `root` / パスワード無しを指しているため、コンテナ側も `MYSQL_ALLOW_EMPTY_PASSWORD` で揃える。CI 専用の使い捨て環境であり、秘密情報の漏洩経路にはならない。
+
+## リスクと対策
+
+最大のリスクは、CI を追加した結果テストが赤いまま放置されることである。基盤だけ作ってテストが 1 本も意味を持たないと、次に誰かが赤を見ても直す動機が湧かない。対策として、今回追加するテストは「壊れたら本当に困るもの」に絞る。具体的には `within_period` の境界条件と `etc` の合計一致の 2 点で、どちらも過去に実際に問題があった箇所である。
+
+このリスクは、テストの中身だけでは防げない。今テストが機能していない直接の原因は「誰も走らせていない」ことであり、CI ジョブ自体が最初から赤いままマージされ続ければ同じ状態の再現になる。対策として、実装順序を「`test.yml` が緑になることを確認してから #38 の本番コード（`etc` 修正）に着手する」に固定する。MySQL サービスコンテナには healthcheck を付け、DB 未起動での接続失敗とテスト自体の失敗を区別できるようにする。Ruby のバージョン取得は既存の `bundler-audit.yml` と同じ `ruby/setup-ruby@v1`（`ruby-version` 未指定）を使う。これは実際に `mise.toml` の `ruby = "3.4.9"` を読んで 3.4.9 をインストールすることを、直近の `bundler-audit` の実行ログ（`Using 3.4.9 as input from file mise.toml`）で確認済みであり、リポジトリに `.ruby-version` が無くても追加設定なしで動く。統合テストは `application.html.erb` 経由でアセット（Sprockets + dartsass）を要求するため、`assets:precompile` またはテスト環境でのアセットコンパイルが CI 上で通ることも実装時に確認する。
+
+次に、fixtures の設計が実データとかけ離れるリスクがある。`bounce_mails` は 137 万行の実データを持つが、fixtures は数件になる。集計ロジックの検証には十分だが、性能特性は再現できない。性能は引き続き Pi での実測に依存する、と割り切る。
+
+三点目として、#38 の修正はチャートの表示数値を変える。これまで見ていた合計が減るため、利用者から見ると「数字が変わった」ように映る。Issue #38 に影響として記載済みだが、リリース時に改めて明示する。
+
+## 残決定事項（判断ポイント）
+
+### 論点1: `etc` の定型をヘルパーへ切り出すか
+
+同じ `slice` / `push` / `select` / `inspect` の定型が 6 箇所に重複している。`_bounced_by_type` だけ入力がソート済み Array で、他の 5 箇所は Hash である。
+
+- A. 各ビューで `slice(0, 3)` / `slice(3..-1)` に直すだけに留める — 利点: 差分が最小で、修正箇所とテストの対応が追いやすい / 欠点: 重複が 6 箇所のまま残り、次に N を変えるとき再び 6 箇所を直すことになる
+- B. `StatsHelper` に `chart_columns(collection, top: 3)` を追加し、6 箇所すべてを置き換える。Hash と Array の差は `to_a` で吸収する — 利点: N が単一の情報源になり、テストもヘルパー 1 本に集約できる / 欠点: ビューの見た目が大きく変わり、diff レビューの負担が増える
+- C. その他（自由記述）
+
+推奨: B。今回まさに「6 箇所を直す」作業をしており、同じことを次も繰り返す構造を残す理由が薄い。ヘルパー単体テストで `etc` の合計一致を直接検証でき、ビュー側のテストは 1 本の代表確認で足りる。
+
+[Answer]: B
+
+### 論点2: CI のトリガ範囲
+
+既存の `bundler-audit.yml` は push to master / pull_request / weekly cron の 3 つで走る。
+
+- A. push to master と pull_request の 2 つ — 利点: PR で結果が見え、master へ入った後も確認される。cron が無いぶん無駄が少ない / 欠点: 依存の更新で壊れるケースは PR が出るまで気づけない
+- B. bundler-audit と同じ 3 つ（weekly cron を含む）— 利点: 外部要因の破損に気づける / 欠点: テストは自リポジトリのコードにしか依存しないため、cron の実行はほぼ常に同じ結果になる
+- C. pull_request のみ — 利点: 最小 / 欠点: master への直接 push が検証されない
+- D. その他（自由記述）
+
+推奨: A。テストは外部の advisory データベースを参照する bundler-audit とは性質が違い、定期実行の価値が低い。
+
+[Answer]: A
+
+### 論点3: 今回書くテストの範囲
+
+基盤を作った上で、どこまでテストを書くか。
+
+- A. `within_period` の境界条件（モデル）と `etc` の合計一致（ヘルパーまたはビュー）、`status_controller_test.rb` の修正の 3 点に絞る — 利点: すべて「過去に実際に問題があった箇所」で、費用対効果が高い / 欠点: `StatsController#index` 全体の描画は covered にならない
+- B. A に加えて `StatsController#index` の統合テストを足し、8 集計ブロックすべてが期間フィルタを反映すること・期間ラベルが出ることを固定の `from`/`to` を指定したリクエストで確認し、別途データの無い固定期間へのリクエストで `No data in this period.` が出ることを確認する — 利点: #36 で手作業検証した内容の主要部分が自動化される / 欠点: fixtures の設計がやや重くなり、リクエストが最低 2 本になる
+- C. B に加えて `BounceMailsController` / `WhitelistMailsController` など他コントローラにも広げる — 利点: カバレッジが上がる / 欠点: 本タスクが発散する
+- D. その他（自由記述）
+
+推奨: B。#36 の検証コストがそのまま次回も掛かる状態を避けたい。fixtures は結局 `bounce_mails` を数件用意する話であり、A から B への増分は大きくない。
+
+[Answer]: B

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: yes
+          MYSQL_DATABASE: sisito_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+    env:
+      RAILS_ENV: test
+      DISABLE_SPRING: 1
+      DATABASE_URL: mysql2://root@127.0.0.1:3306/sisito_test
+      TZ: UTC
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+      - name: Prepare test database
+        run: bin/rails db:create db:schema:load
+      - name: Run tests
+        run: bin/rails test

--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -4,4 +4,15 @@ module StatsHelper
   def stats_period_label(from, to)
     "#{from.strftime('%Y-%m-%d')} 〜 #{to.strftime('%Y-%m-%d')}"
   end
+
+  # 上位 top 件を個別系列、残り全件の合計を 'etc' として返す。
+  # 残りが空なら 'etc' 系列は追加しない（0 件の etc を出さない）。
+  # collection は Hash（key => count）または [key, count] のソート済み配列のどちらでもよい。
+  # 呼び出し元のコレクションは変更しない（drop/first はいずれも非破壊）。
+  def chart_columns(collection, top: 3)
+    pairs = collection.to_a
+    columns = pairs.first(top)
+    remainder = pairs.drop(top)
+    remainder.empty? ? columns : columns + [['etc', remainder.sum {|_, v| v }]]
+  end
 end

--- a/app/views/stats/_bounced_by_type.html.erb
+++ b/app/views/stats/_bounced_by_type.html.erb
@@ -26,12 +26,7 @@
       c3.generate({
         bindto: '<%= "#bounced_by_#{reason}" %>',
         data: {
-          columns: <%= raw(
-            count_by_destination.slice(0, 10)
-              .push(['etc', count_by_destination.map(&:last).slice(3..-1).try(:sum)])
-              .select {|_, v| v.present? }
-              .inspect
-          ) %>,
+          columns: <%= raw chart_columns(count_by_destination).inspect %>,
           type : 'donut'
         },
         donut: {

--- a/app/views/stats/_recent_bounced.html.erb
+++ b/app/views/stats/_recent_bounced.html.erb
@@ -69,12 +69,7 @@
       bindto: '#count_by_destination',
       size: {height: 300},
       data: {
-        columns: <%= raw(
-          @count_by_destination.to_a.slice(0, 10)
-            .push(['etc', @count_by_destination.values.slice(3..-1).try(:sum)])
-            .select {|_, v| v.present? }
-            .inspect
-        ) %>,
+        columns: <%= raw chart_columns(@count_by_destination).inspect %>,
         type : 'pie'
       }
     });
@@ -87,12 +82,7 @@
       bindto: '#count_by_reason',
       size: {height: 300},
       data: {
-        columns: <%= raw(
-          @count_by_reason.to_a.slice(0, 10)
-            .push(['etc', @count_by_reason.values.slice(3..-1).try(:sum)])
-            .select {|_, v| v.present? }
-            .inspect
-        ) %>,
+        columns: <%= raw chart_columns(@count_by_reason).inspect %>,
         type : 'pie'
       }
     });

--- a/app/views/stats/_unique_recipient_bounced.html.erb
+++ b/app/views/stats/_unique_recipient_bounced.html.erb
@@ -27,12 +27,7 @@
     c3.generate({
       bindto: '#uniq_count_by_destination',
       data: {
-        columns: <%= raw(
-          @uniq_count_by_destination.to_a.slice(0, 10)
-            .push(['etc', @uniq_count_by_destination.values.slice(3..-1).try(:sum)])
-            .select {|_, v| v.present? }
-            .inspect
-        ) %>,
+        columns: <%= raw chart_columns(@uniq_count_by_destination).inspect %>,
         type: 'donut'
       },
       donut: {
@@ -47,12 +42,7 @@
     c3.generate({
       bindto: '#uniq_count_by_reason',
       data: {
-        columns: <%= raw(
-          @uniq_count_by_reason.to_a.slice(0, 10)
-            .push(['etc', @uniq_count_by_reason.values.slice(3..-1).try(:sum)])
-            .select {|_, v| v.present? }
-            .inspect
-        ) %>,
+        columns: <%= raw chart_columns(@uniq_count_by_reason).inspect %>,
         type : 'pie'
       }
     });
@@ -64,12 +54,7 @@
     c3.generate({
       bindto: '#uniq_count_by_sender',
       data: {
-        columns: <%= raw(
-          @uniq_count_by_sender.to_a.slice(0, 10)
-            .push(['etc', @uniq_count_by_sender.values.slice(3..-1).try(:sum)])
-            .select {|_, v| v.present? }
-            .inspect
-        ) %>,
+        columns: <%= raw chart_columns(@uniq_count_by_sender).inspect %>,
         type : 'pie'
       }
     });

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
   config.action_controller.perform_caching = false
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/test/controllers/stats_controller_test.rb
+++ b/test/controllers/stats_controller_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class StatsControllerTest < ActionDispatch::IntegrationTest
+  test "reflects the given date range in the aggregation blocks" do
+    get root_path, params: { from: "2026-08-01", to: "2026-08-02" }
+
+    assert_response :success
+    assert_includes response.body, "2026-08-01 〜 2026-08-02"
+    assert_includes response.body, "test1.example.com"
+    assert_includes response.body, "test2.example.com"
+    assert_not_includes response.body, "excluded-before.example.com"
+    assert_not_includes response.body, "excluded-after.example.com"
+  end
+
+  test "shows No data in this period for a range with no bounces" do
+    get root_path, params: { from: "2020-01-01", to: "2020-01-02" }
+
+    assert_response :success
+    assert_includes response.body, "No data in this period."
+  end
+end

--- a/test/controllers/status_controller_test.rb
+++ b/test/controllers/status_controller_test.rb
@@ -1,9 +1,8 @@
 require 'test_helper'
 
-class MonitorControllerTest < ActionDispatch::IntegrationTest
+class StatusControllerTest < ActionDispatch::IntegrationTest
   test "should get index" do
-    get monitor_index_url
+    get status_url
     assert_response :success
   end
-
 end

--- a/test/fixtures/bounce_mails.yml
+++ b/test/fixtures/bounce_mails.yml
@@ -1,0 +1,45 @@
+DEFAULTS: &DEFAULTS
+  lhost: mail.example.com
+  rhost: mail.test1.example.com
+  alias: default@test1.example.com
+  listid: ""
+  reason: userunknown
+  action: failed
+  subject: hello
+  messageid: default@xxx.mail
+  smtpagent: MTA::Postfix
+  hardbounce: false
+  smtpcommand: RCPT
+  destination: test1.example.com
+  senderdomain: example.com
+  feedbacktype: ""
+  diagnosticcode: "550 no such user"
+  deliverystatus: "5.0.0"
+  timezoneoffset: "+0900"
+  addresser: no-reply@example.com
+  addresseralias: ""
+  digest: ""
+
+boundary_start:
+  <<: *DEFAULTS
+  timestamp: 2026-08-01 00:00:00
+  recipient: boundary_start@test1.example.com
+
+day_before_start:
+  <<: *DEFAULTS
+  timestamp: 2026-07-31 23:59:59
+  destination: excluded-before.example.com
+  recipient: day_before_start@excluded-before.example.com
+
+boundary_end:
+  <<: *DEFAULTS
+  timestamp: 2026-08-02 23:59:59
+  reason: filtered
+  destination: test2.example.com
+  recipient: boundary_end@test2.example.com
+
+boundary_next_day:
+  <<: *DEFAULTS
+  timestamp: 2026-08-03 00:00:00
+  destination: excluded-after.example.com
+  recipient: boundary_next_day@excluded-after.example.com

--- a/test/helpers/stats_helper_test.rb
+++ b/test/helpers/stats_helper_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class StatsHelperTest < ActionView::TestCase
+  test "returns individual slices without an etc entry when nothing remains" do
+    assert_equal [["a", 5], ["b", 3], ["c", 1]], chart_columns({"a" => 5, "b" => 3, "c" => 1})
+  end
+
+  test "adds an etc entry summing everything past top" do
+    columns = chart_columns({"a" => 5, "b" => 3, "c" => 1, "d" => 1})
+    assert_equal [["a", 5], ["b", 3], ["c", 1], ["etc", 1]], columns
+  end
+
+  test "does not add an etc entry for fewer than top elements" do
+    assert_equal [["a", 5], ["b", 3]], chart_columns({"a" => 5, "b" => 3})
+  end
+
+  test "does not add an etc entry for an empty collection" do
+    assert_equal [], chart_columns({})
+  end
+
+  test "accepts an already-sorted array of pairs without mutating it" do
+    pairs = [["a", 5], ["b", 3], ["c", 1], ["d", 1]]
+    original = pairs.dup
+    chart_columns(pairs)
+    assert_equal original, pairs
+  end
+
+  test "respects a custom top" do
+    columns = chart_columns({"a" => 4, "b" => 3, "c" => 2, "d" => 1}, top: 2)
+    assert_equal [["a", 4], ["b", 3], ["etc", 3]], columns
+  end
+end

--- a/test/models/bounce_mail_test.rb
+++ b/test/models/bounce_mail_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class BounceMailTest < ActiveSupport::TestCase
+  test "within_period includes the start of the range at 00:00:00" do
+    result = BounceMail.within_period(Date.parse("2026-08-01"), Date.parse("2026-08-02"))
+    assert_includes result, bounce_mails(:boundary_start)
+  end
+
+  test "within_period includes the end of the range at 23:59:59" do
+    result = BounceMail.within_period(Date.parse("2026-08-01"), Date.parse("2026-08-02"))
+    assert_includes result, bounce_mails(:boundary_end)
+  end
+
+  test "within_period excludes the day before the range" do
+    result = BounceMail.within_period(Date.parse("2026-08-01"), Date.parse("2026-08-02"))
+    assert_not_includes result, bounce_mails(:day_before_start)
+  end
+
+  test "within_period excludes the day after the range" do
+    result = BounceMail.within_period(Date.parse("2026-08-01"), Date.parse("2026-08-02"))
+    assert_not_includes result, bounce_mails(:boundary_next_day)
+  end
+end


### PR DESCRIPTION
Closes #38, #39

## 概要

sisito にはテストジョブが `bundler-audit` しか無く、唯一の既存テストも存在しないルート（`monitor_index_url`）を参照した stale なもので、実行すれば `NameError` になっていた（#39）。テスト基盤を先に整備し、その上でダッシュボードのパイ／ドーナツチャート6箇所にある `etc` 系列の二重計上バグ（#38）を回帰テスト付きで修正した。

## 変更内容

`config/environments/test.rb` の `show_exceptions` を Rails 7.2 準拠の `:none` に修正した。`false` のままだと actionpack 7.2.3.2 の `ExceptionWrapper#show?` が `else` に落ち、テスト内の例外が伝播せず 500 ページとして描画されてしまう。

`.github/workflows/test.yml` を追加した。MySQL 8.0 サービスコンテナ、`db:schema:load`（`db:migrate` は使わない。`db/migrate/20170128144003_example_data.rb` が `Date.today - rand(14).days` で非決定的なデータを投入するマイグレーションのため）、`bin/rails test` を実行する。

`BounceMail.within_period` の境界条件（下限含む・上限含む・前日除外・翌日除外）を `test/fixtures/bounce_mails.yml` + `test/models/bounce_mail_test.rb` で固定した。fixtures の共通デフォルトは Rails 標準の `DEFAULTS: &DEFAULTS`（`ActiveRecord::FixtureSet` が無条件に無視する予約キー）をアンカーにしている。

`etc` の二重計上は、`hash.to_a.slice(0, 10).push(['etc', hash.values.slice(3..-1).try(:sum)])` という定型が6箇所にあり、個別表示は10件なのに `etc` は4件目以降を合計していたため、4〜10位が両方に計上されチャート合計が実件数を超えるというバグだった。`StatsHelper#chart_columns(collection, top: 3)` に集約し、個別表示・`etc`集計とも同じ `top` を使うようにした。切り出しには `slice(top..-1)` ではなく `drop(top)` を使い、判定は `present?` ではなく `.empty?` で行っている。`slice(top..-1)` は要素数がちょうど `top` のとき `nil` ではなく `[]` を返すため、旧実装は実際にこの境界で `etc: 0` を出していた（Pi上の実データで `reason=mailboxfull` の3件のケースを再現して確認済み）。個別表示件数を10件から3件に減らしたのは、二重計上を直すために必須ではなく凡例を見やすくする独立した選択（`first(N)` + `drop(N).sum` は N がいくつでも合計が一致するため）。

## 検証

Pi 上の実物の activerecord 7.2.3.2 ソース（`Gemfile.lock` と一致）を読み、`db:schema:load` だけで `maintain_test_schema!` の `PendingMigrationError` が起きないことを事前に確認した。fixtures の日時文字列が CI ランナーの `TZ` に依存して実際に格納される時刻が変わることも発見し（`TZ=UTC`/`Asia/Tokyo`/`America/Los_Angeles` で別プロセス実行して実測）、`.github/workflows/test.yml` に `TZ: UTC` を明示することで対策した。

このPR自体でCIを2回実行して確認している。1回目（テスト基盤のみ）は 5 runs, 9 assertions, 0 failures。2回目（`etc` 修正込み）は 13 runs, 29 assertions, 0 failures。`stats#index` の統合テストがレイアウト経由でアセットパイプライン（Sprockets + dartsass-sprockets）を要求する点も問題なく通った。

レビューは Cursor Agent に依頼した（CLI単発呼び出しとHerdrスペースの対話型エージェントの2系統）。詳細は `.claude/docs/reports/2026-08-11-test-harness-and-etc-slice-fix-result.md` に記録している。

## 対象外

`shorten_stats` や OAuth 経路のテストは含めていない。既存の全コントローラ・全ビューを covered にすることも目指していない。simplecov 等のカバレッジ計測ツールも導入していない。

## デプロイ時の注意

マージ後、Piでダッシュボードを見ると、パイ／ドーナツチャートの個別表示が10件から3件に減る（`etc` に吸収される）。バグ修正に伴う意図した変更だが、運用者への周知が必要。

🤖 implement-verify-record スキルでの実装。ユニットA・B・C すべて完了。