### PR TITLE
fix(security): bump mail to 2.9.1 to fix GHSA-mvxr-6m87-mv2q

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,7 +165,7 @@ GEM
     loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
-    mail (2.9.0)
+    mail (2.9.1)
       logger
       mini_mime (>= 0.1.1)
       net-imap


### PR DESCRIPTION
Closes #46

## 概要

`mail` gem 2.9.0 に対するアドバイザリ GHSA-mvxr-6m87-mv2q（RFC 2047 エンコードワードの不正な形式によるメールアドレス偽装、Medium）を修正する。`mail` はGemfileに直接記載は無く、`Gemfile.lock` 上 `actionmailbox` と `actionmailer`（いずれもRails本体、`mail (>= 2.8.0)`）の2箇所からの推移的依存。確認メール送信（`ConfirmationMailer` → `ActionMailer`）がこの経路で使う。

## 変更内容

`bundle lock --update=mail --conservative` を実行。`git diff Gemfile.lock` は `mail (2.9.0)` → `mail (2.9.1)` の1行のみ。`--conservative` により無関係な推移的依存の巻き込みを防いでいる。

## 検証

ローカル（WSL2）にはgemをインストールしない方針のため、`bundle-audit` 自体の実行はCIに委ねる。`bundle lock` はロックファイルの再解決のみで gem のインストールは行わないため、方針に反しない。

このPRで実際にCIを実行し、`bundler-audit` / `test` とも成功を確認済み。

🤖 Generated with Claude Code